### PR TITLE
[WIP] Add a new argument type: pathname

### DIFF
--- a/test/trollop/parser_test.rb
+++ b/test/trollop/parser_test.rb
@@ -941,6 +941,20 @@ Options:
     assert_raises(CommandlineError) { opts = @p.parse %w(--arg /fdasfasef/fessafef/asdfasdfa/fesasf) }
   end
 
+  def test_pathname_arg_type
+    @p.opt :arg, "desc", :type => :pathname
+    @p.opt :arg2, "desc", :type => Pathname
+    @p.opt :arg3, "desc", :default => Pathname.new('.')
+
+    opts = nil
+    assert_nothing_raised { opts = @p.parse() }
+    assert_equal Pathname.new('.'), opts[:arg3]
+
+    assert_nothing_raised { opts = @p.parse %w(--arg /tmp) }
+    assert_kind_of Pathname , opts[:arg]
+    assert_equal Pathname.new('/tmp'), opts[:arg]
+  end
+
   def test_openstruct_style_access
     @p.opt "arg1", "desc", :type => :int
     @p.opt :arg2, "desc", :type => :int


### PR DESCRIPTION
Hi

I'm using trollop for most of my shell scripts, however, the arguments often involve pathnames. The current :io type is not quite suitable because the pathname arguments point to directories (think: --tempdir /tmp/myscript) which don't even have to exist at the time of argument parsing.

Until now I've treated pathnames as strings, but given the very nice freebies you get when using Pathname instead of String (such as concatting paths with "+" in a platform agnostic manner or "directory?" when traversing filesystems), I had to convert all pathname arguments after parsing them. Not so elegant.

It's not a big change, so I've cloned trollop and implemented the addition and a test for it. Hope you like it.

Cheers, -sven

via [gitorius](https://gitorious.org/trollop/mainline/merge_requests/8)
