### PR TITLE
Added some accessors that allow toggling certain behaviors

### DIFF
--- a/lib/trollop.rb
+++ b/lib/trollop.rb
@@ -126,7 +126,7 @@ class Parser
   ## If you want a multi-value, multi-occurrence argument with a default
   ## value, you must specify +:type+ as well.
 
-  def opt name, desc="", opts={}
+  def opt name, desc="", opts={}, &b
     raise ArgumentError, "you already have an argument named '#{name}'" if @specs.member? name
 
     ## fill in :type
@@ -224,7 +224,7 @@ class Parser
 
     ## fill in :multi
     opts[:multi] ||= false
-
+    opts[:callback] ||= b if block_given?
     opts[:desc] ||= desc
     @long[opts[:long]] = name
     @short[opts[:short]] = name if opts[:short] && opts[:short] != :none

--- a/test/test_trollop.rb
+++ b/test/test_trollop.rb
@@ -1278,6 +1278,22 @@ EOM
       end
     end
   end
+
+  def test_supports_callback_inline
+    assert_raises(RuntimeError, "good") do
+      @p.opt :cb1 do |vals|
+        raise "good"
+      end
+      @p.parse(%w(--cb1))
+    end
+  end
+
+  def test_supports_callback_param
+    assert_raises(RuntimeError, "good") do
+      @p.opt :cb1, "with callback", :callback => lambda { |vals| raise "good" }
+      @p.parse(%w(--cb1))
+    end
+  end
 end
 
 end


### PR DESCRIPTION
First of all, thanks for this library. It's great.

We recently started using it in place of OptionParser for a certain bit of functionality. However, some of the default behaviors were a little too rigid for our use case, so we added some accessors that would allow toggling of some of these behaviors. My belief is that these changes should be transparently backwards compatible.

We also added support for registering callback blocks that are triggered when the parser encounters an option.

We'd love to see this get merged in to the mainline so that we aren't managing a forked version :) Let me know if you think that might be possible!

via [gitorius](https://gitorious.org/trollop/mainline/merge_requests/9)
