### PR TITLE
A tweak to make flags with default values act as switches when passed without args

### DIFF
--- a/lib/trollop.rb
+++ b/lib/trollop.rb
@@ -362,7 +362,10 @@ class Parser
       arg, params, negative_given = given_data.values_at :arg, :params, :negative_given
 
       opts = @specs[sym]
-      raise CommandlineError, "option '#{arg}' needs a parameter" if params.empty? && opts[:type] != :flag
+      if params.empty? && opts[:type] != :flag
+        raise CommandlineError, "option '#{arg}' needs a parameter" unless opts[:default]
+        params << [opts[:default]]
+      end
 
       vals["#{sym}_given".intern] = true # mark argument as specified on the commandline
 

--- a/test/test_trollop.rb
+++ b/test/test_trollop.rb
@@ -178,6 +178,26 @@ class Trollop < ::Test::Unit::TestCase
     assert_nothing_raised { @p.opt "argmst", "desc", :type => :strings, :default => ["yo"] }
   end
 
+  ##
+  def test_flags_with_defaults_and_no_args_act_as_switches
+    opts = nil
+
+    @p.opt :argd, "desc", :default => "default_string"
+
+    opts = @p.parse(%w(--))
+    assert !opts[:argd_given]
+    assert_equal "default_string", opts[:argd]
+
+    opts = @p.parse(%w( --argd ))
+    assert opts[:argd_given]
+    assert_equal "default_string", opts[:argd]
+
+    opts = @p.parse(%w(--argd different_string))
+    assert opts[:argd_given]
+    assert_equal "different_string", opts[:argd]
+
+  end
+
   def test_long_detects_bad_names
     assert_nothing_raised { @p.opt "goodarg", "desc", :long => "none" }
     assert_nothing_raised { @p.opt "goodarg2", "desc", :long => "--two" }


### PR DESCRIPTION
When a script is configured with:

```
opts = Trollop::options do
  opts :argwithdefault, "An Argument w/ a default", :default => "default value"
end
```

Then trying:

```
command --arg-with-default
```

Seems like we should get the default value rather than an error.

via [gitorius](https://gitorious.org/trollop/mainline/merge_requests/11)
