### PR TITLE
Allow empty arrays as defaults when the type is explicitly given.

### DIFF
--- a/lib/trollop.rb
+++ b/lib/trollop.rb
@@ -169,7 +169,11 @@ class Parser
       when Date; :date
       when Array
         if opts[:default].empty?
-          raise ArgumentError, "multiple argument type cannot be deduced from an empty array for '#{opts[:default][0].class.name}'"
+          if opts[:type]
+            nil
+          else
+            raise ArgumentError, "multiple argument type cannot be deduced from an empty array for '#{opts[:default][0].class.name}'"
+          end
         end
         case opts[:default][0]    # the first element determines the types
         when Integer; :ints


### PR DESCRIPTION
I don't believe that the following should blow up.

``` ruby
opt    :skip, "Skip a space-separated list of components.", type: :strings, default: []
```

We check to see if a type is explicitly given, and become happy.

Again, sorry about the lack of tests.
