### PR TITLE
Remove version file to align with the single-file rule

### DIFF
--- a/lib/trollop.rb
+++ b/lib/trollop.rb
@@ -3,10 +3,10 @@
 ## Copyright:: Copyright 2007 William Morgan
 ## License::   the same terms as ruby itself
 
-require "trollop/version"
 require 'date'
 
 module Trollop
+VERSION = "2.0.1"
 
 ## Thrown by Parser in the event of a commandline error. Not needed if
 ## you're using the Trollop::options entry.

--- a/lib/trollop/version.rb
+++ b/lib/trollop/version.rb
@@ -1,3 +1,0 @@
-module Trollop
-  VERSION = "2.0.1"
-end

--- a/trollop.gemspec
+++ b/trollop.gemspec
@@ -1,7 +1,7 @@
 # coding: utf-8
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'trollop/version'
+require 'trollop'
 
 Gem::Specification.new do |spec|
   spec.name          = "trollop"


### PR DESCRIPTION
One of trollop's features is to be a single file, so you are
not required to use as a gem.  The version file being
separate breaks that rule.

See https://github.com/ManageIQ/trollop/blob/master/README.md#features

Fixes #21
