### PR TITLE
New features

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ rvm:
   - "2.0"
   - "2.1"
   - "2.2"
+  - "2.3.4"
+  - "2.4.1"
   - ruby-head
   - jruby-head
 gemfile: Gemfile.travis

--- a/README.md
+++ b/README.md
@@ -8,8 +8,11 @@ http://manageiq.github.io/trollop/
 [![Coverage Status](http://img.shields.io/coveralls/ManageIQ/trollop.svg)](https://coveralls.io/r/ManageIQ/trollop)
 [![Dependency Status](https://gemnasium.com/ManageIQ/trollop.svg)](https://gemnasium.com/ManageIQ/trollop)
 
-Documentation quickstart: See Trollop.options and then Trollop::Parser#opt.
-Also see the examples at http://manageiq.github.io/trollop/.
+## Documentation
+
+- Quickstart: See `Trollop.options` and then `Trollop::Parser#opt`.
+- Examples: http://manageiq.github.io/trollop/.
+- Wiki: http://github.com/ManageIQ/trollop/wiki
 
 ## Description
 

--- a/lib/trollop.rb
+++ b/lib/trollop.rb
@@ -231,13 +231,16 @@ class Parser
 
   def handle_unknown_argument(arg, candidates, suggestions)
     errstring = "unknown argument '#{arg}'"
-    if suggestions and  Module::const_defined?("DidYouMean::JaroWinkler") and Module::const_defined?("DidYouMean::Levenshtein")
+    if (suggestions &&
+        Module::const_defined?("DidYouMean") &&
+        Module::const_defined?("DidYouMean::JaroWinkler") &&
+        Module::const_defined?("DidYouMean::Levenshtein"))
       input = arg.sub(/^[-]*/,'')
-      #require 'did_you_mean'
+
       # Code borrowed from did_you_mean gem
       jw_threshold = 0.75
-      seed = candidates.select {|candidate| DidYouMean::JaroWinkler.distance(candidate, input) >= jw_threshold }
-               .sort_by! {|candidate| DidYouMean::JaroWinkler.distance(candidate.to_s, input) }
+      seed = candidates.select {|candidate| DidYouMean::JaroWinkler.distance(candidate, input) >= jw_threshold } \
+               .sort_by! {|candidate| DidYouMean::JaroWinkler.distance(candidate.to_s, input) } \
                .reverse!
       # Correct mistypes
       threshold   = (input.length * 0.25).ceil

--- a/lib/trollop.rb
+++ b/lib/trollop.rb
@@ -462,6 +462,7 @@ class Parser
 
   ## The per-parser version of Trollop::die (see that for documentation).
   def die(arg, msg = nil, error_code = nil)
+    msg, error_code = nil, msg if msg.kind_of?(Fixnum)
     if msg
       $stderr.puts "Error: argument --#{@specs[arg].long} #{msg}."
     else
@@ -891,6 +892,10 @@ end
 ##   end
 ##
 ##   Trollop::die "need at least one filename" if ARGV.empty?
+##
+## An exit code can be provide if needed
+##
+##   Trollop::die "need at least one filename", -2 if ARGV.empty?
 def die(arg, msg = nil, error_code = nil)
   if @last_parser
     @last_parser.die arg, msg, error_code

--- a/test/trollop/parser_educate_test.rb
+++ b/test/trollop/parser_educate_test.rb
@@ -2,7 +2,7 @@ require 'stringio'
 require 'test_helper'
 
 module Trollop
-  class ParserEduateTest < ::MiniTest::Test
+  class ParserEducateTest < ::MiniTest::Test
     def setup
     end
 
@@ -136,16 +136,16 @@ module Trollop
     parser.educate sio
 
     help = sio.string.split "\n"
-    assert help[1] =~ /<i>/
-    assert help[2] =~ /<i\+>/
-    assert help[3] =~ /<s>/
-    assert help[4] =~ /<s\+>/
-    assert help[5] =~ /<f>/
-    assert help[6] =~ /<f\+>/
-    assert help[7] =~ /<filename\/uri>/
-    assert help[8] =~ /<filename\/uri\+>/
-    assert help[9] =~ /<date>/
-    assert help[10] =~ /<date\+>/
+    assert help[1] =~ /<i>/, 'expect :int type'
+    assert help[2] =~ /<i\+>/, 'expect :ints type'
+    assert help[3] =~ /<s>/, 'expect :string type'
+    assert help[4] =~ /<s\+>/, 'expect :strings type'
+    assert help[5] =~ /<f>/, 'expect :float type'
+    assert help[6] =~ /<f\+>/, 'expect :floats type'
+    assert help[7] =~ /<filename\/uri>/, 'expect :io type'
+    assert help[8] =~ /<filename\/uri\+>/, 'expect :ios type'
+    assert help[9] =~ /<date>/, 'expect :date type'
+    assert help[10] =~ /<date\+>/, 'expect :dates type'
   end
 
   def test_help_has_grammatical_default_text
@@ -155,9 +155,34 @@ module Trollop
     parser.educate sio
 
     help = sio.string.split "\n"
-    assert help[1] =~ /Default/
-    assert help[2] =~ /default/
+    assert help[1] =~ /Default/, "expected 'Default' for arg1"
+    assert help[2] =~ /default/, "expected 'default' for arg2"
   end
+  
+  def test_help_can_hide_options
+    parser.opt :unhidden, 'standard option', :default => 'foo'
+    parser.opt :hideopt, 'secret option', :default => 'bar', :hidden => true
+    parser.opt :afteropt, 'post hidden option', :default => 'baz'
+    sio = StringIO.new 'w'
+    parser.educate sio
+    help = sio.string.split "\n"
+    assert help[1] =~ /\-\-unhidden/, 'expect first printed option to be unhidden'
+    # secret/hidden option should not be written out
+    assert help[2] =~ /\-\-afteropt/, 'expect second printed option to be the one after the hideopt option'
+  end
+
+  def test_help_has_no_shortopts_when_set
+    @p = Parser.new(:disable_auto_short_opts => true)
+    parser.opt :fooey, 'fooey option'
+    sio = StringIO.new "w"
+    @p.parse []
+    @p.educate sio
+    help = sio.string.split "\n"
+    assert help[1].match(/\-\-fooey/), 'long option appears in help'
+    assert !help[1].match(/[^-]\-f/), 'short -f option does not appear in help'
+    assert !help[2].match(/[^-]\-h/), 'short -h option does not appear in help'
+  end
+
 ############
 
     private

--- a/test/trollop/parser_test.rb
+++ b/test/trollop/parser_test.rb
@@ -58,7 +58,9 @@ class ParserTest < ::MiniTest::Test
     err = assert_raises(CommandlineError) { sugp.parse(%w(--bone)) }
     assert_match(/unknown argument '--bone'$/, err.message)
 
-    if Module::const_defined?("DidYouMean::JaroWinkler") and Module::const_defined?("DidYouMean::Levenshtein")
+    if (Module::const_defined?("DidYouMean") &&
+        Module::const_defined?("DidYouMean::JaroWinkler") &&
+        Module::const_defined?("DidYouMean::Levenshtein"))
       sugp.opt "cone"
       sugp.parse(%w(--cone))
 

--- a/test/trollop/parser_test.rb
+++ b/test/trollop/parser_test.rb
@@ -1144,6 +1144,56 @@ Options:
       @p.parse(%w(--cb1))
     end
   end
+
+  def test_ignore_invalid_options
+    @p.opt :arg1, "desc", :type => String
+    @p.opt :b, "desc", :type => String
+    @p.opt :c, "desc", :type => :flag
+    @p.opt :d, "desc", :type => :flag
+    @p.ignore_invalid_options = true
+    opts = @p.parse %w{unknown -S param --arg1 potato -fb daisy --foo -ecg --bar baz -z}
+    assert_equal "potato", opts[:arg1]
+    assert_equal "daisy", opts[:b]
+    assert opts[:c]
+    refute opts[:d]
+    assert_equal %w{unknown -S param -f --foo -eg --bar baz -z}, @p.leftovers
+  end
+
+  def test_ignore_invalid_options_stop_on_unknown_long
+    @p.opt :arg1, "desc", :type => String
+    @p.ignore_invalid_options = true
+    @p.stop_on_unknown
+    opts = @p.parse %w{--unk --arg1 potato}
+    refute opts[:arg1]
+    assert_equal %w{--unk --arg1 potato}, @p.leftovers
+  end
+
+  def test_ignore_invalid_options_stop_on_unknown_short
+    @p.opt :arg1, "desc", :type => String
+    @p.ignore_invalid_options = true
+    @p.stop_on_unknown
+    opts = @p.parse %w{-ua potato}
+    refute opts[:arg1]
+    assert_equal %w{-ua potato}, @p.leftovers
+  end
+
+  def test_ignore_invalid_options_stop_on_unknown_partial_end_short
+    @p.opt :arg1, "desc", :type => :flag
+    @p.ignore_invalid_options = true
+    @p.stop_on_unknown
+    opts = @p.parse %w{-au potato}
+    assert opts[:arg1]
+    assert_equal %w{-u potato}, @p.leftovers
+  end
+
+  def test_ignore_invalid_options_stop_on_unknown_partial_mid_short
+    @p.opt :arg1, "desc", :type => :flag
+    @p.ignore_invalid_options = true
+    @p.stop_on_unknown
+    opts = @p.parse %w{-abu potato}
+    assert opts[:arg1]
+    assert_equal %w{-bu potato}, @p.leftovers
+  end
 end
 
 end

--- a/test/trollop/parser_test.rb
+++ b/test/trollop/parser_test.rb
@@ -45,15 +45,60 @@ class ParserTest < ::MiniTest::Test
 
 
   def test_unknown_arguments
-    assert_raises(CommandlineError) { @p.parse(%w(--arg)) }
+    err = assert_raises(CommandlineError) { @p.parse(%w(--arg)) }
+    assert_match(/unknown argument '--arg'$/, err.message)
     @p.opt "arg"
     @p.parse(%w(--arg))
-    assert_raises(CommandlineError) { @p.parse(%w(--arg2)) }
+    err = assert_raises(CommandlineError) { @p.parse(%w(--arg2)) }
+    assert_match(/unknown argument '--arg2'$/, err.message)
   end
 
+  def test_unknown_arguments_with_suggestions
+    sugp = Parser.new(:suggestions => true)
+    err = assert_raises(CommandlineError) { sugp.parse(%w(--bone)) }
+    assert_match(/unknown argument '--bone'$/, err.message)
+
+    if Module::const_defined?("DidYouMean::JaroWinkler") and Module::const_defined?("DidYouMean::Levenshtein")
+      sugp.opt "cone"
+      sugp.parse(%w(--cone))
+
+      # single letter mismatch
+      err = assert_raises(CommandlineError) { sugp.parse(%w(--bone)) }
+      assert_match(/unknown argument '--bone'.  Did you mean: \[--cone\] \?$/, err.message)
+
+      # transposition
+      err = assert_raises(CommandlineError) { sugp.parse(%w(--ocne)) }
+      assert_match(/unknown argument '--ocne'.  Did you mean: \[--cone\] \?$/, err.message)
+
+      # extra letter at end
+      err = assert_raises(CommandlineError) { sugp.parse(%w(--cones)) }
+      assert_match(/unknown argument '--cones'.  Did you mean: \[--cone\] \?$/, err.message)
+
+      # too big of a mismatch to suggest (extra letters in front)
+      err = assert_raises(CommandlineError) { sugp.parse(%w(--snowcone)) }
+      assert_match(/unknown argument '--snowcone'$/, err.message)
+
+      # too big of a mismatch to suggest (nothing close)
+      err = assert_raises(CommandlineError) { sugp.parse(%w(--clown-nose)) }
+      assert_match(/unknown argument '--clown-nose'$/, err.message)
+
+      sugp.opt "zippy"
+      sugp.opt "zapzy"
+      # single letter mismatch, matches two
+      err = assert_raises(CommandlineError) { sugp.parse(%w(--zipzy)) }
+      assert_match(/unknown argument '--zipzy'.  Did you mean: \[--zippy, --zapzy\] \?$/, err.message)
+
+      sugp.opt "big_bug"
+      # suggest common case of dash versus underscore in argnames
+      err = assert_raises(CommandlineError) { sugp.parse(%w(--big_bug)) }
+      assert_match(/unknown argument '--big_bug'.  Did you mean: \[--big-bug\] \?$/, err.message)
+    end
+    
+  end
+
+  
   def test_syntax_check
     @p.opt "arg"
-
     @p.parse(%w(--arg))
     @p.parse(%w(arg))
     assert_raises(CommandlineError) { @p.parse(%w(---arg)) }
@@ -688,6 +733,19 @@ Options:
     assert_equal @goat, boat
   end
 
+  ## test-only access reader method so that we dont have to
+  ## expose settings in the public API.
+  class Trollop::Parser
+    def get_settings_for_testing ; return @settings ;end
+  end
+  
+  def test_two_arguments_passed_through_block
+    newp = Parser.new(:abcd => 123, :efgh => 456 ) do |i|
+    end
+    assert_equal newp.get_settings_for_testing[:abcd], 123
+    assert_equal newp.get_settings_for_testing[:efgh], 456
+  end
+
   def test_version_and_help_override_errors
     @p.opt :asdf, "desc", :type => String
     @p.version "version"
@@ -1039,6 +1097,56 @@ Options:
     assert opts[:ccd]
   end
 
+  def test_default_shorts_prevented_with_setting
+    newp = Parser.new(:disable_auto_short_opts => true)
+    newp.opt :user1, "user1"
+    newp.opt :bag, "bag", :short => 'b'
+    assert_raises(CommandlineError) do
+      newp.parse %w(-u)
+    end
+    opts = newp.parse %w(--user1)
+    assert opts[:user1]
+    opts = newp.parse %w(-b)
+    assert opts[:bag]
+  end
+
+  def test_inexact_match
+    newp = Parser.new(:inexact_match => true)
+    newp.opt :liberation, "liberate something", :type => :int
+    newp.opt :evaluate, "evaluate something", :type => :string
+    opts = newp.parse %w(--lib 5 --ev bar)
+    assert_equal 5, opts[:liberation]
+    assert_equal 'bar', opts[:evaluate]
+    assert_equal nil, opts[:eval]
+  end
+
+  def test_inexact_collision
+    newp = Parser.new(:inexact_match => true)
+    newp.opt :bookname, "name of a book", :type => :string
+    newp.opt :bookcost, "cost of the book", :type => :string
+    opts = newp.parse %w(--bookn hairy_potsworth --bookc 10)
+    assert_equal 'hairy_potsworth', opts[:bookname]
+    assert_equal '10', opts[:bookcost]
+    assert_raises(CommandlineError) do
+      newp.parse %w(--book 5) # ambiguous
+    end
+    ## partial match causes 'specified multiple times' error
+    assert_raises(CommandlineError, /specified multiple times/) do
+      newp.parse %w(--bookc 17 --bookcost 22)
+    end
+  end
+
+  def test_inexact_collision_with_exact
+    newp = Parser.new(:inexact_match => true)
+    newp.opt :book, "name of a book", :type => :string, :default => "ABC"
+    newp.opt :bookcost, "cost of the book", :type => :int, :default => 5
+    opts = newp.parse %w(--book warthog --bookc 3)
+    assert_equal 'warthog', opts[:book]
+    assert_equal 3, opts[:bookcost]
+
+  end
+
+  
   def test_accepts_arguments_with_spaces
     @p.opt :arg1, "arg", :type => String
     @p.opt :arg2, "arg2", :type => String
@@ -1194,6 +1302,37 @@ Options:
     assert opts[:arg1]
     assert_equal %w{-bu potato}, @p.leftovers
   end
+
+  # Due to strangeness in how the cloaker works, there were
+  # cases where Trollop.parse would work, but Trollop.options
+  # did not, depending on arguments given to the function.
+  # These serve to validate different args given to Trollop.options
+  def test_options_takes_hashy_settings
+    passargs_copy = []
+    settings_copy = []
+    ::Trollop.options(%w(--wig --pig), :fizz=>:buzz, :bear=>:cat) do |*passargs|
+      opt :wig
+      opt :pig
+      passargs_copy = passargs.dup
+      settings_copy = @settings
+    end
+    assert_equal [], passargs_copy
+    assert_equal({:fizz=>:buzz, :bear=>:cat}, settings_copy)
+  end
+  
+  def test_options_takes_some_other_data
+    passargs_copy = []
+    settings_copy = []
+    ::Trollop.options(%w(--nose --close), 1, 2, 3) do |*passargs|
+      opt :nose
+      opt :close
+      passargs_copy = passargs.dup
+      settings_copy = @settings
+    end
+    assert_equal [1,2,3], passargs_copy
+    assert_equal({}, settings_copy)
+  end
+  
 end
 
 end

--- a/test/trollop_test.rb
+++ b/test/trollop_test.rb
@@ -60,6 +60,15 @@ class TrollopTest < MiniTest::Test
     end
   end
 
+  def test_die_custom_error_code_two_args
+    assert_stderr(/Error: issue with parsing/) do
+      assert_system_exit(5) do
+        Trollop.options []
+        Trollop.die "issue with parsing", 5
+      end
+    end
+  end
+
   def test_educate_without_options_ever_run
     assert_raises(ArgumentError) { Trollop.educate }
   end


### PR DESCRIPTION
A few new features added:

1. allow hidden options - ones that dont print with `educate`
2. "global" settings to enable behavior similar to Perl's Getopt::Long
3. prevent short-flags from being generated for each option by default
this is more convenient than setting `:short => :none` for each option
IMX, users often forget to use two dashes for long opts and then inadvertently trigger short-opts, e.g., instead of triggering option ` --dog`, they effectively trigger `-d -o -g`, or `-d og`
4. enable loose matching of options for the shortest unambiguous match.  Given options `apple`, `apricot` and `antelope`, you could trigger them with `--app, --apr, and --an`, respectively.  

Tests and some amount of documentation also included.
