### PR TITLE
Added 'permitted' parameter for options, deprecated Fixnum

### DIFF
--- a/lib/trollop.rb
+++ b/lib/trollop.rb
@@ -152,6 +152,8 @@ class Parser
     raise ArgumentError, "you already have an argument named '#{name}'" if @specs.member? o.name
     raise ArgumentError, "long option name #{o.long.inspect} is already taken; please specify a (different) :long" if @long[o.long]
     raise ArgumentError, "short option name #{o.short.inspect} is already taken; please specify a (different) :short" if @short[o.short]
+    raise ArgumentError, "permitted values for option #{o.long.inspect} must be either nil or an array;" unless o.permitted.nil? or o.permitted.is_a? Array
+
     @long[o.long] = o.name
     @short[o.short] = o.name if o.short?
     @specs[o.name] = o
@@ -322,6 +324,10 @@ class Parser
         params << (opts.array_default? ? opts.default.clone : [opts.default])
       end
 
+      params[0].each do |p|
+        raise CommandlineError, "option '#{arg}' only accepts one of: #{opts.permitted.join(', ')}" unless opts.permitted.include? p
+      end unless opts.permitted.nil?
+
       vals["#{sym}_given".intern] = true # mark argument as specified on the commandline
 
       vals[sym] = opts.parse(params, negative_given)
@@ -382,7 +388,7 @@ class Parser
 
       spec = @specs[opt]
       stream.printf "  %-#{leftcol_width}s    ", left[opt]
-      desc = spec.description_with_default
+      desc = spec.full_description
 
       stream.puts wrap(desc, :width => width - rightcol_start - 1, :prefix => rightcol_start)
     end
@@ -577,7 +583,7 @@ end
 
 class Option
 
-  attr_accessor :name, :short, :long, :default
+  attr_accessor :name, :short, :long, :default, :permitted
   attr_writer :multi_given
   
   def initialize
@@ -587,6 +593,7 @@ class Option
     @multi_given = false
     @hidden = false
     @default = nil
+    @permitted = nil
     @optshash = Hash.new()
   end
   
@@ -631,9 +638,16 @@ class Option
     (short? ? "-#{short}, " : "") + "--#{long}" + type_format + (flag? && default ? ", --no-#{long}" : "")
   end
 
+  ## Format the educate-line description including the default and permitted value(s)
+  def full_description
+    desc_str = desc
+    desc_str = description_with_default desc_str if default
+    desc_str = description_with_permitted desc_str if permitted
+    desc_str
+  end
+
   ## Format the educate-line description including the default-value(s)
-  def description_with_default
-    return desc unless default
+  def description_with_default str
     default_s = case default
                 when $stdout   then '<stdout>'
                 when $stdin    then '<stdin>'
@@ -643,8 +657,24 @@ class Option
                 else
                   default.to_s
                 end
-    defword = desc.end_with?('.') ? 'Default' : 'default'
-    return "#{desc} (#{defword}: #{default_s})"
+    defword = str.end_with?('.') ? 'Default' : 'default'
+    return "#{str} (#{defword}: #{default_s})"
+  end
+
+  ## Format the educate-line description including the permitted-value(s)
+  def description_with_permitted str
+    permitted_s = permitted.map do |p|
+      case p
+      when $stdout   then '<stdout>'
+      when $stdin    then '<stdin>'
+      when $stderr   then '<stderr>'
+      else
+        p.to_s
+      end
+    end.join(', ')
+
+    permword = str.end_with?('.') ? 'Permitted' : 'permitted'
+    return "#{str} (#{permword}: #{permitted_s})"
   end
 
   ## Provide a way to register symbol aliases to the Parser
@@ -681,10 +711,14 @@ class Option
     opt_inst.multi_given = multi_given
 
     ## fill in :default for flags
-    defvalue = opts[:default] || opt_inst.default 
+    defvalue = opts[:default] || opt_inst.default
+
+    ## fill in permitted values
+    permitted = opts[:permitted] || nil
 
     ## autobox :default for :multi (multi-occurrence) arguments
     defvalue = [defvalue] if defvalue && multi_given && !defvalue.kind_of?(Array)
+    opt_inst.permitted = permitted
     opt_inst.default = defvalue
     opt_inst.name = name
     opt_inst.opts = opts

--- a/lib/trollop.rb
+++ b/lib/trollop.rb
@@ -431,7 +431,7 @@ class Parser
 
   ## The per-parser version of Trollop::die (see that for documentation).
   def die(arg, msg = nil, error_code = nil)
-    msg, error_code = nil, msg if msg.kind_of?(Fixnum)
+    msg, error_code = nil, msg if msg.kind_of?(Integer)
     if msg
       $stderr.puts "Error: argument --#{@specs[arg].long} #{msg}."
     else


### PR DESCRIPTION
Using `permitted:` restricts the allowed values that a end-user inputs to a pre-defined list. For example:

   `opt :name, type: string, permitted: ['Jack', 'Jill']`

means the user can only do one of the following:

   $ mycmd -n Jack
   $ mycmd -n Jill

It also works for multi-parameters

   $ mycmd -n Jack Jill

Additionally, Fixnum has been deprecated since Ruby 2.4.0, and a warning message appears for users. It has been merged into `Integer`. The `opt` type can still be set to :Fixnum, however, to maintain backwards compatibility of the gem itself.