### PR TITLE
fix #102 address Ruby 2.4 messages 'warning: parentheses after method name is …

### DIFF
--- a/lib/optimist.rb
+++ b/lib/optimist.rb
@@ -590,11 +590,11 @@ class Option
     @optshash = Hash.new()
   end
 
-  def opts (key)
+  def opts(key)
     @optshash[key]
   end
 
-  def opts= (o)
+  def opts=(o)
     @optshash = o
   end
 
@@ -620,7 +620,7 @@ class Option
 
   def required? ; opts(:required) ; end
 
-  def parse (_paramlist, _neg_given)
+  def parse(_paramlist, _neg_given)
     raise NotImplementedError, "parse must be overridden for newly registered type"
   end
 


### PR DESCRIPTION
…interpreted as an argument list, not a decomposed argument'

I removed the space between the method name and the opening parenthesis. This resolved the warning messages. All tests pass locally.