### PR TITLE
Add :stopped to opts when stopped by on_stop

### DIFF
--- a/lib/optimist.rb
+++ b/lib/optimist.rb
@@ -351,6 +351,7 @@ class Parser
         self[m] || self[m.to_s]
       end
     end
+    vals[:stopped] = @stopped || false unless @stop_words.empty?
     vals
   end
 
@@ -448,7 +449,10 @@ private
     i = 0
 
     until i >= args.length
-      return remains += args[i..-1] if @stop_words.member? args[i]
+      if @stop_words.member? args[i]
+        @stopped = true
+        return remains += args[i..-1]
+      end
       case args[i]
       when /^--$/ # arg terminator
         return remains += args[(i + 1)..-1]

--- a/test/optimist/parser_test.rb
+++ b/test/optimist/parser_test.rb
@@ -876,6 +876,19 @@ Options:
     assert_equal @q.leftovers, []
   end
 
+  def test_stopwords_stopped
+    @p.stop_on %w(sub-command-1)
+    opts = @p.parse %w(sub-command-1)
+
+    assert_equal true, opts[:stopped]
+
+    @q = Parser.new
+    @q.stop_on %w(sub-command-1)
+    opts = @q.parse %w(sub-command-2)
+
+    assert_equal false, opts[:stopped]
+  end
+
   def test_unknown_subcommand
     @p.opt :global_flag, "Global flag", :short => "-g", :type => :flag
     @p.opt :global_param, "Global parameter", :short => "-p", :default => 5


### PR DESCRIPTION
I would like to have the parser set a value if on_stop finds a keyword in the args. Otherwise I need to parse the first argument of ARGV in order to determine whether or not a valid command was given (in a command/subcommand scenario).

Only adds it if on_stop exists.