### PR TITLE
Fix test warnings

### DIFF
--- a/test/optimist/parser_test.rb
+++ b/test/optimist/parser_test.rb
@@ -390,12 +390,12 @@ class ParserTest < ::MiniTest::Test
     opts = @p.parse %w(-a -b)
     assert_equal true, opts[:arg1]
     assert_equal true, opts[:arg2]
-    assert_equal nil, opts[:arg3]
+    assert_nil opts[:arg3]
 
     opts = @p.parse %w(-ab)
     assert_equal true, opts[:arg1]
     assert_equal true, opts[:arg2]
-    assert_equal nil, opts[:arg3]
+    assert_nil opts[:arg3]
 
     opts = @p.parse %w(-ac 4 -b)
     assert_equal true, opts[:arg1]
@@ -464,7 +464,7 @@ Options:
     assert_equal 5, opts[:arg]
   end
 
-  def test_integer_formatting
+  def test_integer_formatting_default
     @p.opt :arg, "desc", :type => :integer, :short => "i", :default => 3
     opts = @p.parse %w(-i)
     assert_equal 3, opts[:arg]


### PR DESCRIPTION
There were warnings when running `rake`.
This fixes them.

The warnings:
1) `DEPRECATED: Use assert_nil if expecting nil`
2) `warning: method redefined; discarding old test_integer_formatting` and `warning: previous definition of test_integer_formatting was here`

The fixes:
* 1 was fixed by using the suggested `assert_nil`
* 2 was fixed by suffixing the duplicate test with `"_default"`