### PR TITLE
Added settings that optionally enable inexact_match and suggestions

### DIFF
--- a/lib/optimist.rb
+++ b/lib/optimist.rb
@@ -99,8 +99,18 @@ class Parser
     @synopsis = nil
     @usage = nil
 
+    ## allow passing settings through Parser.new as an optional hash.
+    ## but keep compatibility with non-hashy args, though.
+    begin
+      @settings = Hash[*a]
+      a=[] ## clear out args if using as settings-hash
+    rescue ArgumentError
+      @settings = Hash.new()
+    end
+
     # instance_eval(&b) if b # can't take arguments
-    cloaker(&b).bind(self).call(*a) if b
+    #cloaker(&b).bind(self).call(*a) if b
+    self.instance_exec(*a, &b) if block_given?
   end
 
   ## Define an option. +name+ is the option name, a unique identifier
@@ -226,6 +236,56 @@ class Parser
     @educate_on_error = true
   end
 
+  ## Match long variables with inexact match.
+  ## If we hit a complete match, then use that, otherwise see how many long-options partially match.
+  ## If only one partially matches, then we can safely use that.
+  ## Otherwise, we raise an error that the partially given option was ambiguous.
+  def perform_inexact_match (arg, partial_match)  # :nodoc:
+    return @long[partial_match] if @long.has_key?(partial_match)
+    partially_matched_keys = @long.keys.grep(/^#{partial_match}/)
+    return case partially_matched_keys.size
+           when 0 ; nil
+           when 1 ; @long[partially_matched_keys.first]
+           else ; raise CommandlineError, "ambiguous option '#{arg}' matched keys (#{partially_matched_keys.join(',')})"
+           end
+  end
+  private :perform_inexact_match
+
+  def handle_unknown_argument(arg, candidates, suggestions)
+    errstring = "unknown argument '#{arg}'"
+    if (suggestions &&
+        Module::const_defined?("DidYouMean") &&
+        Module::const_defined?("DidYouMean::JaroWinkler") &&
+        Module::const_defined?("DidYouMean::Levenshtein"))
+      input = arg.sub(/^[-]*/,'')
+
+      # Code borrowed from did_you_mean gem
+      jw_threshold = 0.75
+      seed = candidates.select {|candidate| DidYouMean::JaroWinkler.distance(candidate, input) >= jw_threshold } \
+               .sort_by! {|candidate| DidYouMean::JaroWinkler.distance(candidate.to_s, input) } \
+               .reverse!
+      # Correct mistypes
+      threshold   = (input.length * 0.25).ceil
+      has_mistype = seed.rindex {|c| DidYouMean::Levenshtein.distance(c, input) <= threshold }
+      corrections = if has_mistype
+                      seed.take(has_mistype + 1)
+                    else
+                      # Correct misspells
+                      seed.select do |candidate|
+                        length    = input.length < candidate.length ? input.length : candidate.length
+
+                        DidYouMean::Levenshtein.distance(candidate, input) < length
+                      end.first(1)
+                    end
+      unless corrections.empty?
+        dashdash_corrections = corrections.map{|s| "--#{s}" }
+        errstring << ".  Did you mean: [#{dashdash_corrections.join(', ')}] ?"
+      end
+    end
+    raise CommandlineError, errstring 
+  end
+  private :handle_unknown_argument
+
   ## Parses the commandline. Typically called by Optimist::options,
   ## but you can call it directly if you need more control.
   ##
@@ -263,8 +323,13 @@ class Parser
 
       sym = nil if arg =~ /--no-/ # explicitly invalidate --no-no- arguments
 
+      ## Support inexact matching of long-arguments like perl's Getopt::Long
+      if @settings[:inexact_match] and arg.match(/^--(\S*)$/)
+        sym = perform_inexact_match(arg, $1)
+      end
+      
       next nil if ignore_invalid_options && !sym
-      raise CommandlineError, "unknown argument '#{arg}'" unless sym
+      handle_unknown_argument(arg, @long.keys, @settings[:suggestions]) unless sym
 
       if given_args.include?(sym) && !@specs[sym].multi?
         raise CommandlineError, "option '#{arg}' specified multiple times"
@@ -915,6 +980,20 @@ end
 ##
 ##   ## if called with --monkey
 ##   p opts # => {:monkey=>true, :name=>nil, :num_limbs=>4, :help=>false, :monkey_given=>true}
+##
+## Settings:
+##   Optimist::options and Optimist::Parser.new accept +settings+ to control how
+##   options are interpreted.  These settings are given as hash arguments, e.g:
+##
+##   opts = Optimist::options(ARGV, :inexact_match => true) do
+##     opt :foobar, 'messed up'
+##     opt :forget, 'forget it'
+##   end
+##
+##  +settings+ include:
+##  * :inexact_match  : Allow minimum unambigous number of characters to match a long option
+##  * :suggestions  : Enables suggestions when unknown arguments are given and DidYouMean is installed.  DidYouMean comes standard with Ruby 2.3+
+##  Because Optimist::options uses a default argument for +args+, you must pass that argument when using the settings feature.
 ##
 ## See more examples at http://optimist.rubyforge.org.
 def options(args = ARGV, *a, &b)

--- a/test/optimist/parser_test.rb
+++ b/test/optimist/parser_test.rb
@@ -45,10 +45,57 @@ class ParserTest < ::MiniTest::Test
 
 
   def test_unknown_arguments
-    assert_raises(CommandlineError) { @p.parse(%w(--arg)) }
+    err = assert_raises(CommandlineError) { @p.parse(%w(--arg)) }
+    assert_match(/unknown argument '--arg'$/, err.message)
     @p.opt "arg"
     @p.parse(%w(--arg))
-    assert_raises(CommandlineError) { @p.parse(%w(--arg2)) }
+    err = assert_raises(CommandlineError) { @p.parse(%w(--arg2)) }
+    assert_match(/unknown argument '--arg2'$/, err.message)
+  end
+  
+  def test_unknown_arguments_with_suggestions
+    sugp = Parser.new(:suggestions => true)
+    err = assert_raises(CommandlineError) { sugp.parse(%w(--bone)) }
+    assert_match(/unknown argument '--bone'$/, err.message)
+
+    if (Module::const_defined?("DidYouMean") &&
+        Module::const_defined?("DidYouMean::JaroWinkler") &&
+        Module::const_defined?("DidYouMean::Levenshtein"))
+      sugp.opt "cone"
+      sugp.parse(%w(--cone))
+
+      # single letter mismatch
+      err = assert_raises(CommandlineError) { sugp.parse(%w(--bone)) }
+      assert_match(/unknown argument '--bone'.  Did you mean: \[--cone\] \?$/, err.message)
+
+      # transposition
+      err = assert_raises(CommandlineError) { sugp.parse(%w(--ocne)) }
+      assert_match(/unknown argument '--ocne'.  Did you mean: \[--cone\] \?$/, err.message)
+
+      # extra letter at end
+      err = assert_raises(CommandlineError) { sugp.parse(%w(--cones)) }
+      assert_match(/unknown argument '--cones'.  Did you mean: \[--cone\] \?$/, err.message)
+
+      # too big of a mismatch to suggest (extra letters in front)
+      err = assert_raises(CommandlineError) { sugp.parse(%w(--snowcone)) }
+      assert_match(/unknown argument '--snowcone'$/, err.message)
+
+      # too big of a mismatch to suggest (nothing close)
+      err = assert_raises(CommandlineError) { sugp.parse(%w(--clown-nose)) }
+      assert_match(/unknown argument '--clown-nose'$/, err.message)
+
+      sugp.opt "zippy"
+      sugp.opt "zapzy"
+      # single letter mismatch, matches two
+      err = assert_raises(CommandlineError) { sugp.parse(%w(--zipzy)) }
+      assert_match(/unknown argument '--zipzy'.  Did you mean: \[--zippy, --zapzy\] \?$/, err.message)
+
+      sugp.opt "big_bug"
+      # suggest common case of dash versus underscore in argnames
+      err = assert_raises(CommandlineError) { sugp.parse(%w(--big_bug)) }
+      assert_match(/unknown argument '--big_bug'.  Did you mean: \[--big-bug\] \?$/, err.message)
+    end
+    
   end
 
   def test_syntax_check
@@ -705,6 +752,20 @@ Options:
     end
     assert_equal @goat, boat
   end
+  
+  ## test-only access reader method so that we dont have to
+  ## expose settings in the public API.
+  class Optimist::Parser
+    def get_settings_for_testing ; return @settings ;end
+  end
+  
+  def test_two_arguments_passed_through_block
+    newp = Parser.new(:abcd => 123, :efgh => "other" ) do |i|
+    end
+    assert_equal newp.get_settings_for_testing[:abcd], 123
+    assert_equal newp.get_settings_for_testing[:efgh], "other"
+  end
+
 
   def test_version_and_help_override_errors
     @p.opt :asdf, "desc", :type => String
@@ -1060,6 +1121,42 @@ Options:
     assert opts[:ccd]
   end
 
+  def test_inexact_match
+    newp = Parser.new(:inexact_match => true)
+    newp.opt :liberation, "liberate something", :type => :int
+    newp.opt :evaluate, "evaluate something", :type => :string
+    opts = newp.parse %w(--lib 5 --ev bar)
+    assert_equal 5, opts[:liberation]
+    assert_equal 'bar', opts[:evaluate]
+    assert_equal nil, opts[:eval]
+  end
+
+  def test_inexact_collision
+    newp = Parser.new(:inexact_match => true)
+    newp.opt :bookname, "name of a book", :type => :string
+    newp.opt :bookcost, "cost of the book", :type => :string
+    opts = newp.parse %w(--bookn hairy_potsworth --bookc 10)
+    assert_equal 'hairy_potsworth', opts[:bookname]
+    assert_equal '10', opts[:bookcost]
+    assert_raises(CommandlineError) do
+      newp.parse %w(--book 5) # ambiguous
+    end
+    ## partial match causes 'specified multiple times' error
+    assert_raises(CommandlineError, /specified multiple times/) do
+      newp.parse %w(--bookc 17 --bookcost 22)
+    end
+  end
+
+  def test_inexact_collision_with_exact
+    newp = Parser.new(:inexact_match => true)
+    newp.opt :book, "name of a book", :type => :string, :default => "ABC"
+    newp.opt :bookcost, "cost of the book", :type => :int, :default => 5
+    opts = newp.parse %w(--book warthog --bookc 3)
+    assert_equal 'warthog', opts[:book]
+    assert_equal 3, opts[:bookcost]
+
+  end
+
   def test_accepts_arguments_with_spaces
     @p.opt :arg1, "arg", :type => String
     @p.opt :arg2, "arg2", :type => String
@@ -1214,6 +1311,36 @@ Options:
     opts = @p.parse %w{-abu potato}
     assert opts[:arg1]
     assert_equal %w{-bu potato}, @p.leftovers
+  end
+
+  # Due to strangeness in how the cloaker works, there were
+  # cases where Optimist.parse would work, but Optimist.options
+  # did not, depending on arguments given to the function.
+  # These serve to validate different args given to Optimist.options
+  def test_options_takes_hashy_settings
+    passargs_copy = []
+    settings_copy = []
+    ::Optimist.options(%w(--wig --pig), :fizz=>:buzz, :bear=>:cat) do |*passargs|
+      opt :wig
+      opt :pig
+      passargs_copy = passargs.dup
+      settings_copy = @settings
+    end
+    assert_equal [], passargs_copy
+    assert_equal({:fizz=>:buzz, :bear=>:cat}, settings_copy)
+  end
+  
+  def test_options_takes_some_other_data
+    passargs_copy = []
+    settings_copy = []
+    ::Optimist.options(%w(--nose --close), 1, 2, 3) do |*passargs|
+      opt :nose
+      opt :close
+      passargs_copy = passargs.dup
+      settings_copy = @settings
+    end
+    assert_equal [1,2,3], passargs_copy
+    assert_equal({}, settings_copy)
   end
 end
 


### PR DESCRIPTION
+ Added Settings:
   Optimist::options and Optimist::Parser.new accept `settings` to control how
   options are interpreted.  These settings are given as hash arguments, e.g:
```ruby
   opts = Optimist::options(ARGV, :inexact_match => true) do
     opt :foobar, 'messed up'
     opt :forget, 'forget it'
   end
```
`settings` include:
+ `:inexact_match`  : Allow minimum unambigous number of characters to match a long option
+ `:suggestions`    : Enables suggestions when unknown arguments are given and DidYouMean is installed.  Note: DidYouMean comes standard with Ruby 2.3+

Because `Optimist::options` uses a default argument for _args_ (typically ARGV), you must pass that argument when using the settings feature.