### PR TITLE
Remove `2.2` and `2.3` from CI matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: ruby
 cache: bundler
 rvm:
-  - 2.2
-  - 2.3
   - 2.4
   - 2.5
   - 2.6


### PR DESCRIPTION
In the previous commit 5a61393b14c1a9ef4db0b332f730e5167b1585dc
`manageiq-style` has been introduced.
https://github.com/okuramasafumi/optimist/blob/master/optimist.gemspec#L33
This gem includes `rubocop` which doesn't work with Ruby 2.2 and 2.3.
In the error log of TravisCI, it says:
```
manageiq-style was resolved to 1.1.3, which depends on
  rubocop (~> 0.82.0) was resolved to 0.82.0, which depends on
    ruby (>= 2.4.0)
```
I believe we should drop support for older Rubies such as 2.2 and 2.3,
because using RuboCop means we cannot use Ruby 2.3 and older, and
Ruby 2.3 is so old and not supported anymore (EOL).