### PR TITLE
Add some tests cases to ParserTest

### DIFF
--- a/test/optimist/parser_test.rb
+++ b/test/optimist/parser_test.rb
@@ -253,6 +253,8 @@ class ParserTest < ::MiniTest::Test
   def test_long_detects_bad_names
     @p.opt "goodarg", "desc", :long => "none"
     @p.opt "goodarg2", "desc", :long => "--two"
+    @p.opt "goodarg3", "desc", :long => "arg-3"
+    @p.opt "goodarg4", "desc", :long => "--good-arg-four"
     assert_raises(ArgumentError) { @p.opt "badarg", "desc", :long => "" }
     assert_raises(ArgumentError) { @p.opt "badarg2", "desc", :long => "--" }
     assert_raises(ArgumentError) { @p.opt "badarg3", "desc", :long => "-one" }

--- a/test/optimist/parser_test.rb
+++ b/test/optimist/parser_test.rb
@@ -347,6 +347,14 @@ class ParserTest < ::MiniTest::Test
     assert_equal true, opts[:defaultfalse]
     assert_equal true, opts[:defaulttrue]
 
+    ## using short form turns them all on, regardless of default
+    #
+    # (matches positve "non-no" long form)
+    opts = @p.parse %w(-d -e -f)
+    assert_equal true, opts[:defaultnone]
+    assert_equal true, opts[:defaultfalse]
+    assert_equal true, opts[:defaulttrue]
+
     ## using --no- form turns them off, regardless of default
     opts = @p.parse %w(--no-defaultfalse --no-defaulttrue --no-defaultnone)
     assert_equal false, opts[:defaultnone]
@@ -374,6 +382,14 @@ class ParserTest < ::MiniTest::Test
 
     ## using dropped-no form turns them all off, regardless of default
     opts = @p.parse %w(--default-false --default-true --default-none)
+    assert_equal false, opts[:no_default_none]
+    assert_equal false, opts[:no_default_false]
+    assert_equal false, opts[:no_default_true]
+
+    ## using short form turns them all off, regardless of default
+    #
+    # (matches positve "non-no" long form)
+    opts = @p.parse %w(-n -o -d)
     assert_equal false, opts[:no_default_none]
     assert_equal false, opts[:no_default_false]
     assert_equal false, opts[:no_default_true]


### PR DESCRIPTION
Adds tests for the following cases:

- Short flags for boolean cases
- Long opt names with dashes