### PR TITLE
Migrate to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: Tests
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby-version:
+          - '3.1'
+          - '3.0'
+          - '2.7'
+          - '2.6'
+          - '2.5'
+          - '2.4'
+          - jruby-9.3
+          - ruby-head
+          - jruby-head
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby ${{ matrix.ruby-version }}
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby-version }}
+        bundler-cache: true # 'bundle install' and cache
+    - name: Run tests
+      run: bundle exec rake

--- a/optimist.gemspec
+++ b/optimist.gemspec
@@ -32,5 +32,5 @@ specify."
   spec.add_development_dependency "chronic"
   spec.add_development_dependency "manageiq-style"
   spec.add_development_dependency "minitest",      "~> 5.4.3"
-  spec.add_development_dependency "rake",          "~> 10.0"
+  spec.add_development_dependency "rake",          ">= 10.0"
 end


### PR DESCRIPTION
This PR moves CI to GitHub Actions

In addition to setting up a basic configuration that includes those Rubies previously tested by Travis this PR:

1. Adds jruby-9.3 and Ruby 3.1 to the CI matrix
2. Loosens the Rake requirement in the gemspec to allow a Rake version that's compatible with ruby-head