### PR TITLE
Test: use recent Minitest style

### DIFF
--- a/test/optimist/command_line_error_test.rb
+++ b/test/optimist/command_line_error_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 module Optimist
-  class CommandlineErrorTest < ::MiniTest::Test
+  class CommandlineErrorTest < ::Minitest::Test
     def test_class
       assert_kind_of Exception, cle("message")
     end

--- a/test/optimist/help_needed_test.rb
+++ b/test/optimist/help_needed_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 module Optimist
-  class HelpNeededTest < ::MiniTest::Test
+  class HelpNeededTest < ::Minitest::Test
     def test_class
       assert_kind_of Exception, hn("message")
     end

--- a/test/optimist/parser_educate_test.rb
+++ b/test/optimist/parser_educate_test.rb
@@ -2,7 +2,7 @@ require 'stringio'
 require 'test_helper'
 
 module Optimist
-  class ParserEduateTest < ::MiniTest::Test
+  class ParserEduateTest < ::Minitest::Test
     def setup
     end
 

--- a/test/optimist/parser_opt_test.rb
+++ b/test/optimist/parser_opt_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 
 module Optimist
 
-  class ParserOptTest < ::MiniTest::Test
+  class ParserOptTest < ::Minitest::Test
 
     private
 

--- a/test/optimist/parser_parse_test.rb
+++ b/test/optimist/parser_parse_test.rb
@@ -2,7 +2,7 @@ require 'stringio'
 require 'test_helper'
 
 module Optimist
-  class ParserParseTest < ::MiniTest::Test
+  class ParserParseTest < ::Minitest::Test
 
   # TODO: parse
     # resolve_default_short_options!

--- a/test/optimist/parser_test.rb
+++ b/test/optimist/parser_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 
 module Optimist
 
-class ParserTest < ::MiniTest::Test
+class ParserTest < ::Minitest::Test
   def setup
     @p = Parser.new
   end

--- a/test/optimist/version_needed_test.rb
+++ b/test/optimist/version_needed_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 module Optimist
-  class VersionNeededTest < ::MiniTest::Test
+  class VersionNeededTest < ::Minitest::Test
     def test_class
       assert_kind_of Exception, vn("message")
     end

--- a/test/optimist_test.rb
+++ b/test/optimist_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class OptimistTest < MiniTest::Test
+class OptimistTest < Minitest::Test
   def setup
     Optimist.send(:instance_variable_set, "@last_parser", nil)
   end


### PR DESCRIPTION
Current style has long been to use Minitest instead of MiniTest at least for 3 years, and with minitest 5.19, MiniTest usage support is hidden unless explicitly setting ENV["MT_COMPAT"].

https://github.com/minitest/minitest/commit/a2c6c18570f6f0a1bf6af70fe3b6d9599a13fdd6

Switch to use Minitest style.