### PR TITLE
Align the short and long forms into their own columns in the help output

### DIFF
--- a/lib/optimist.rb
+++ b/lib/optimist.rb
@@ -636,7 +636,7 @@ class Option
   def type_format ; "" ; end
 
   def educate
-    (short? ? "-#{short}, " : "") + "--#{long}" + type_format + (flag? && default ? ", --no-#{long}" : "")
+    (short? ? "-#{short}, " : "    ") + "--#{long}" + type_format + (flag? && default ? ", --no-#{long}" : "")
   end
 
   ## Format the educate-line description including the default-value(s)

--- a/test/optimist/parser_test.rb
+++ b/test/optimist/parser_test.rb
@@ -471,8 +471,8 @@ with a multi-line description
     @p.educate(out)
     assert_equal <<-EOM, out.string
 Options:
-  --arg=<i>    This is an arg
-               with a multi-line description
+      --arg=<i>    This is an arg
+                   with a multi-line description
     EOM
   end
 


### PR DESCRIPTION
This makes displaying a mixed set of parameters cleaner and easier to understand. This is in line with the behavior of common GNU tools such as rsync.

Old way:
```
Options:
  -i, --init        Creates a skeleton config file in the current working directory
  -v, --verbose     Enables verbose output. Twice will enable very-verbose output (good for logging)
  -y, --yes         Assume 'yes' to all questions for headless execution
  --yaml=<s>        Specify a yaml file to load
  -h, --help        Show this message
```

New way:
```
Options:
  -i, --init        Creates a skeleton config file in the current working directory
  -v, --verbose     Enables verbose output. Twice will enable very-verbose output (good for logging)
  -y, --yes         Assume 'yes' to all questions for headless execution
      --yaml=<s>    Specify a yaml file to load
  -h, --help        Show this message
```

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
