### PR TITLE
Allow multi-flag parameters

### DIFF
--- a/lib/optimist.rb
+++ b/lib/optimist.rb
@@ -245,7 +245,8 @@ class Parser
     @specs.each do |sym, opts|
       required[sym] = true if opts.required?
       vals[sym] = opts.default
-      vals[sym] = [] if opts.multi && !opts.default # multi arguments default to [], not nil
+      vals[sym] = [] if opts.multi && !opts.default && !opts.flag? # multi arguments default to [], not nil
+      vals[sym] = 0 if opts.multi && !opts.default && opts.flag? # multi argument flags default to 0 because they return a count
     end
 
     resolve_default_short_options!
@@ -282,6 +283,11 @@ class Parser
 
       # The block returns the number of parameters taken.
       num_params_taken = 0
+
+      if @specs[sym].multi? && @specs[sym].flag?
+        given_args[sym][:params][0] ||= 0
+        given_args[sym][:params][0] += 1
+      end
 
       unless params.empty?
         if @specs[sym].single_arg?
@@ -765,6 +771,7 @@ class BooleanOption < Option
   end
   def flag? ; true ; end
   def parse(_paramlist, neg_given)
+    return _paramlist[0] if @multi_given
     return(self.name.to_s =~ /^no_/ ? neg_given : !neg_given)
   end
 end

--- a/test/optimist/parser_test.rb
+++ b/test/optimist/parser_test.rb
@@ -565,19 +565,19 @@ Options:
     assert_equal [], @p.leftovers
   end
 
-  def test_short_options_with_multiple_options_does_not_affect_flags_type
+  def test_short_options_with_multiple_options_flag_types_get_counted
     @p.opt :xarg, "desc", :short => "-x", :type => :flag, :multi => true
 
     opts = @p.parse %w(-x a)
-    assert_equal true, opts[:xarg]
+    assert_equal 1, opts[:xarg]
     assert_equal %w(a), @p.leftovers
 
     opts = @p.parse %w(-x a -x b)
-    assert_equal true, opts[:xarg]
+    assert_equal 2, opts[:xarg]
     assert_equal %w(a b), @p.leftovers
 
     opts = @p.parse %w(-xx a -x b)
-    assert_equal true, opts[:xarg]
+    assert_equal 3, opts[:xarg]
     assert_equal %w(a b), @p.leftovers
   end
 
@@ -1116,10 +1116,16 @@ Options:
     assert_equal 0, @p.leftovers.size
   end
 
-  def test_multi_args_default_to_empty_array
-    @p.opt :arg1, "arg", :multi => true
+  def test_multi_args_with_specified_type_defaults_to_empty_array
+    @p.opt :arg1, "arg", :type => :string, :multi => true
     opts = @p.parse []
     assert_equal [], opts[:arg1]
+  end
+
+  def test_multi_args_with_type_flag_defaults_to_zero
+    @p.opt :arg1, "arg", :multi => true
+    opts = @p.parse []
+    assert_equal 0, opts[:arg1]
   end
 
   def test_simple_interface_handles_help


### PR DESCRIPTION
Some tools need to allow the repeated input of certain valueless parameters. One such example is the use of `v` for `verbose`, where the addition of more v's increases the verbosity of the output. This behavior can be seen in tools such as curl and ssh.

Prior to this change, when the `:multi` option was passed in to a `:flag` or `:boolean` parameter, the parser would return either a a `true` value or an empty array depending on if the flag was passed in the command line or not. This is an unusual paradigm and provides no extra functionality over regular `:flag` parameters.

After this change, the `:flag` with `:multi` set will instead count the number of times the flag was passed. Flag options without `:multi` set still exhibit the original behavior of simple `true`/`false` values.

Example config:
```ruby
opts = Optimist::options do
    opt :verbose, "Enables verbose output. Twice will enable very-verbose output", multi: true
end
```

Before change:
```
$ mytool
{:verbose => []}

$ mytool -vvv
{:verbose => true}
```

After change:
```
$ mytool
{:verbose => 0}

$ mytool -vvv
{:verbose => 3}
```
