### PR TITLE
Using permitted: restricts the allowed values that a end-user inputs to a pre-defined list

### DIFF
--- a/lib/optimist.rb
+++ b/lib/optimist.rb
@@ -114,6 +114,7 @@ class Parser
   ## [+:default+] Set the default value for an argument. Without a default value, the hash returned by #parse (and thus Optimist::options) will have a +nil+ value for this key unless the argument is given on the commandline. The argument type is derived automatically from the class of the default value given, so specifying a +:type+ is not necessary if a +:default+ is given. (But see below for an important caveat when +:multi+: is specified too.) If the argument is a flag, and the default is set to +true+, then if it is specified on the the commandline the value will be +false+.
   ## [+:required+] If set to +true+, the argument must be provided on the commandline.
   ## [+:multi+] If set to +true+, allows multiple occurrences of the option on the commandline. Otherwise, only a single instance of the option is allowed. (Note that this is different from taking multiple parameters. See below.)
+  ## [+:permitted+] Specify an Array of permitted values for an option. If the user provides a value outside this list, an error is thrown.
   ##
   ## Note that there are two types of argument multiplicity: an argument
   ## can take multiple values, e.g. "--arg 1 2 3". An argument can also

--- a/lib/optimist.rb
+++ b/lib/optimist.rb
@@ -150,6 +150,7 @@ class Parser
     raise ArgumentError, "you already have an argument named '#{name}'" if @specs.member? o.name
     raise ArgumentError, "long option name #{o.long.inspect} is already taken; please specify a (different) :long" if @long[o.long]
     raise ArgumentError, "short option name #{o.short.inspect} is already taken; please specify a (different) :short" if @short[o.short]
+    raise ArgumentError, "permitted values for option #{o.long.inspect} must be either nil or an array;" unless o.permitted.nil? or o.permitted.is_a? Array
     @long[o.long] = o.name
     @short[o.short] = o.name if o.short?
     @specs[o.name] = o
@@ -330,6 +331,10 @@ class Parser
         params << (opts.array_default? ? opts.default.clone : [opts.default])
       end
 
+      params[0].each do |p|
+        raise CommandlineError, "option '#{arg}' only accepts one of: #{opts.permitted.join(', ')}" unless opts.permitted.include? p
+      end unless opts.permitted.nil?
+
       vals["#{sym}_given".intern] = true # mark argument as specified on the commandline
 
       vals[sym] = opts.parse(params, negative_given)
@@ -390,7 +395,7 @@ class Parser
 
       spec = @specs[opt]
       stream.printf "  %-#{leftcol_width}s    ", left[opt]
-      desc = spec.description_with_default
+      desc = spec.full_description
 
       stream.puts wrap(desc, :width => width - rightcol_start - 1, :prefix => rightcol_start)
     end
@@ -585,7 +590,7 @@ end
 
 class Option
 
-  attr_accessor :name, :short, :long, :default
+  attr_accessor :name, :short, :long, :default, :permitted
   attr_writer :multi_given
 
   def initialize
@@ -595,6 +600,7 @@ class Option
     @multi_given = false
     @hidden = false
     @default = nil
+    @permitted = nil
     @optshash = Hash.new()
   end
 
@@ -639,9 +645,16 @@ class Option
     (short? ? "-#{short}, " : "") + "--#{long}" + type_format + (flag? && default ? ", --no-#{long}" : "")
   end
 
-  ## Format the educate-line description including the default-value(s)
-  def description_with_default
-    return desc unless default
+  ## Format the educate-line description including the default and permitted value(s)
+  def full_description
+    desc_str = desc
+    desc_str += default_description_str(desc) if default
+    desc_str += permitted_description_str(desc) if permitted
+    desc_str
+  end
+
+  ## Generate the default value string for the educate line
+  private def default_description_str str
     default_s = case default
                 when $stdout   then '<stdout>'
                 when $stdin    then '<stdin>'
@@ -651,8 +664,23 @@ class Option
                 else
                   default.to_s
                 end
-    defword = desc.end_with?('.') ? 'Default' : 'default'
-    return "#{desc} (#{defword}: #{default_s})"
+    defword = str.end_with?('.') ? 'Default' : 'default'
+    " (#{defword}: #{default_s})"
+  end
+
+  ## Generate the permitted values string for the educate line
+  private def permitted_description_str str
+    permitted_s = permitted.map do |p|
+      case p
+      when $stdout   then '<stdout>'
+      when $stdin    then '<stdin>'
+      when $stderr   then '<stderr>'
+      else
+        p.to_s
+      end
+    end.join(', ')
+    permword = str.end_with?('.') ? 'Permitted' : 'permitted'
+    " (#{permword}: #{permitted_s})"
   end
 
   ## Provide a way to register symbol aliases to the Parser
@@ -691,8 +719,12 @@ class Option
     ## fill in :default for flags
     defvalue = opts[:default] || opt_inst.default
 
+    ## fill in permitted values
+    permitted = opts[:permitted] || nil
+
     ## autobox :default for :multi (multi-occurrence) arguments
     defvalue = [defvalue] if defvalue && multi_given && !defvalue.kind_of?(Array)
+    opt_inst.permitted = permitted
     opt_inst.default = defvalue
     opt_inst.name = name
     opt_inst.opts = opts

--- a/test/optimist/parser_educate_test.rb
+++ b/test/optimist/parser_educate_test.rb
@@ -158,6 +158,17 @@ module Optimist
     assert help[1] =~ /Default/
     assert help[2] =~ /default/
   end
+
+  def test_help_has_grammatical_permitted_text
+    parser.opt :arg1, 'description with period.', :type => :strings, :permitted => %w(foo bar)
+    parser.opt :arg2, 'description without period', :type => :strings, :permitted => %w(foo bar)
+    sio = StringIO.new 'w'
+    parser.educate sio
+
+    help = sio.string.split "\n"
+    assert help[1] =~ /Permitted/
+    assert help[2] =~ /permitted/
+  end
 ############
 
     private

--- a/test/optimist/parser_test.rb
+++ b/test/optimist/parser_test.rb
@@ -71,6 +71,14 @@ class ParserTest < ::Minitest::Test
     assert_raises(CommandlineError) { @p.parse(%w(--arg2 --arg3)) }
   end
 
+  def test_permitted_flags_filter_inputs
+    @p.opt "arg", "desc", :type => :strings, :permitted => %w(foo bar)
+
+    result = @p.parse(%w(--arg foo))
+    assert_equal ["foo"], result["arg"]
+    assert_raises(CommandlineError) { @p.parse(%w(--arg baz)) }
+  end
+
   ## flags that take an argument error unless given one
   def test_argflags_demand_args
     @p.opt "goodarg", "desc", :type => String


### PR DESCRIPTION
Using `permitted:` when defining an option restricts the allowed values that a end-user inputs to a pre-defined list.

__Note__: This is a continuation of an old PR which I accidentally closed by deleting my old fork (it was too old to use now). [This is the PR](https://github.com/ManageIQ/optimist/pull/97). It is now rebased as requested, and I have added the tests, but I never got a final answer if you wanted it merged in this form or if you wanted to do something else. I've been using my own fork for the last few years and so far I haven't hit any issues with the code as written.

Defining an option like this...

```ruby
opt :name, type: strings, permitted: ['Jack', 'Jill']
```

...restricts the input to one of the following:

```shell
$ mycmd -n Jack
$ mycmd -n Jill
$ mycmd -n Jack Jill
```

Any other input will raise a `CommandlineError` in line with other features.