### PR TITLE
Add alt longname and multiple char support

### DIFF
--- a/examples/alt_names.rb
+++ b/examples/alt_names.rb
@@ -1,0 +1,20 @@
+#!/usr/bin/env ruby
+require_relative '../lib/optimist'
+
+opts = Optimist::options do
+  # 'short:' can now take more than one short-option character
+  #   you can specify 'short:' as a string/symbol or an array of strings/symbols
+  # 'alt:' adds additional long-opt choices (over the original name or the long: name)
+  #   you can specify 'alt:' as a string/symbol or an array of strings/symbols.
+  # 
+  opt :concat, 'concatenate flag', short: ['-C', 'A'], alt: ['cat', '--append']
+  opt :array_len, 'set Array length', long: 'size', alt: 'length', type: Integer
+end
+
+p opts
+
+# $ ./alt_names.rb -h
+# Options:
+#   -C, -A, --concat, --cat, --append    concatenate flag
+#   -s, --size, --length=<i>             set Array length
+#   -h, --help                           Show this message

--- a/lib/optimist.rb
+++ b/lib/optimist.rb
@@ -703,12 +703,15 @@ class ShortNames
 
   def add(values)
     values = [values] unless values.is_a?(Array) # box the value
-    values.compact.each do |val|
-      if val == :none
+    values = values.compact
+    if values.include?(:none)
+      if values.size == 1
         @auto = false
-        raise "Cannot set short to :none if short-chars have been defined '#{@chars}'" unless chars.empty?
-        next
+        return
       end
+      raise ArgumentError, "Cannot use :none with any other values in short option: #{values.inspect}"
+    end
+    values.each do |val|
       strval = val.to_s
       sopt = case strval
              when /^-(.)$/ then $1

--- a/lib/optimist.rb
+++ b/lib/optimist.rb
@@ -70,8 +70,6 @@ class Parser
     return @registry[lookup].new
   end
 
-  INVALID_SHORT_ARG_REGEX = /[\d-]/ #:nodoc:
-
   ## The values from the commandline that were not interpreted by #parse.
   attr_reader :leftovers
 
@@ -166,11 +164,19 @@ class Parser
     o = Option.create(name, desc, opts)
 
     raise ArgumentError, "you already have an argument named '#{name}'" if @specs.member? o.name
-    raise ArgumentError, "long option name #{o.long.inspect} is already taken; please specify a (different) :long" if @long[o.long]
-    raise ArgumentError, "short option name #{o.short.inspect} is already taken; please specify a (different) :short" if @short[o.short]
+    
+    o.long.names.each do |lng|
+      raise ArgumentError, "long option name #{lng.inspect} is already taken; please specify a (different) :long/:alt" if @long[lng]
+      @long[lng] = o.name
+    end
+
+    o.short.chars.each do |short|
+      raise ArgumentError, "short option name #{short.inspect} is already taken; please specify a (different) :short" if @short[short]
+      @short[short] = o.name
+    end
+
     raise ArgumentError, "permitted values for option #{o.long.inspect} must be either nil or an array;" unless o.permitted.nil? or o.permitted.is_a? Array
-    @long[o.long] = o.name
-    @short[o.short] = o.name if o.short?
+    
     @specs[o.name] = o
     @order << [:opt, o.name]
   end
@@ -619,11 +625,10 @@ private
   def resolve_default_short_options!
     @order.each do |type, name|
       opts = @specs[name]
-      next if type != :opt || opts.short
-
-      c = opts.long.chars.find { |d| d !~ INVALID_SHORT_ARG_REGEX && !@short.member?(d) }
+      next if type != :opt || opts.doesnt_need_autogen_short
+      c = opts.long.long.split(//).find { |d| d !~ Optimist::ShortNames::INVALID_ARG_REGEX && !@short.member?(d) }
       if c # found a character to use
-        opts.short = c
+        opts.short.add c
         @short[c] = name
       end
     end
@@ -651,14 +656,83 @@ private
 
 end
 
+class LongNames
+  def initialize
+    @truename = nil
+    @long = nil
+    @alts = []
+  end
+
+  def make_valid(lopt)
+    return nil if lopt.nil?
+    case lopt.to_s
+    when /^--([^-].*)$/ then $1
+    when /^[^-]/        then lopt.to_s
+    else                     raise ArgumentError, "invalid long option name #{lopt.inspect}"
+    end
+  end
+
+  def set(name, lopt, alts)
+    @truename = name
+    lopt = lopt ? lopt.to_s : name.to_s.gsub("_", "-")
+    @long = make_valid(lopt)
+    alts = [alts] unless alts.is_a?(Array) # box the value
+    @alts = alts.map { |alt| make_valid(alt) }.compact
+  end
+
+  # long specified with :long has precedence over the true-name
+  def long ; @long || @truename ; end
+
+  # all valid names, including alts
+  def names
+    [long] + @alts
+  end
+
+end
+
+class ShortNames
+
+  INVALID_ARG_REGEX = /[\d-]/ #:nodoc:
+
+  def initialize
+    @chars = []
+    @auto = true
+  end
+
+  attr_reader :chars, :auto
+
+  def add(values)
+    values = [values] unless values.is_a?(Array) # box the value
+    values.compact.each do |val|
+      if val == :none
+        @auto = false
+        raise "Cannot set short to :none if short-chars have been defined '#{@chars}'" unless chars.empty?
+        next
+      end
+      strval = val.to_s
+      sopt = case strval
+             when /^-(.)$/ then $1
+             when /^.$/ then strval
+             else raise ArgumentError, "invalid short option name '#{val.inspect}'"
+             end
+
+      if sopt =~ INVALID_ARG_REGEX
+        raise ArgumentError, "short option name '#{sopt}' can't be a number or a dash" 
+      end
+      @chars << sopt
+    end
+  end
+
+end
+
 class Option
 
   attr_accessor :name, :short, :long, :default, :permitted
   attr_writer :multi_given
 
   def initialize
-    @long = nil
-    @short = nil
+    @long = LongNames.new
+    @short = ShortNames.new # can be an Array of one-char strings, a one-char String, nil or :none
     @name = nil
     @multi_given = false
     @hidden = false
@@ -690,7 +764,7 @@ class Option
 
   def array_default? ; self.default.kind_of?(Array) ; end
 
-  def short? ; short && short != :none ; end
+  def doesnt_need_autogen_short ; !short.auto || short.chars.any? ; end
 
   def callback ; opts(:callback) ; end
   def desc ; opts(:desc) ; end
@@ -705,7 +779,10 @@ class Option
   def type_format ; "" ; end
 
   def educate
-    (short? ? "-#{short}, " : "    ") + "--#{long}" + type_format + (flag? && default ? ", --no-#{long}" : "")
+    optionlist = []
+    optionlist.concat(short.chars.map { |o| "-#{o}" })
+    optionlist.concat(long.names.map { |o| "--#{o}" })
+    optionlist.compact.join(', ') + type_format + (flag? && default ? ", --no-#{long}" : "")
   end
 
   ## Format the educate-line description including the default and permitted value(s)
@@ -770,10 +847,10 @@ class Option
     opt_inst = (opttype || opttype_from_default || Optimist::BooleanOption.new)
 
     ## fill in :long
-    opt_inst.long = handle_long_opt(opts[:long], name)
+    opt_inst.long.set(name, opts[:long], opts[:alt])
 
     ## fill in :short
-    opt_inst.short = handle_short_opt(opts[:short])
+    opt_inst.short.add opts[:short]
 
     ## fill in :multi
     multi_given = opts[:multi] || false
@@ -824,29 +901,6 @@ class Option
     return nil if disambiguated_default.nil?
     type_from_default = get_type_from_disdef(opts[:default], opttype, disambiguated_default)
     return Optimist::Parser.registry_getopttype(type_from_default)
-  end
-
-  def self.handle_long_opt(lopt, name)
-    lopt = lopt ? lopt.to_s : name.to_s.gsub("_", "-")
-    lopt = case lopt
-           when /^--([^-].*)$/ then $1
-           when /^[^-]/        then lopt
-           else                     raise ArgumentError, "invalid long option name #{lopt.inspect}"
-           end
-  end
-
-  def self.handle_short_opt(sopt)
-    sopt = sopt.to_s if sopt && sopt != :none
-    sopt = case sopt
-           when /^-(.)$/          then $1
-           when nil, :none, /^.$/ then sopt
-           else                   raise ArgumentError, "invalid short option name '#{sopt.inspect}'"
-           end
-
-    if sopt
-      raise ArgumentError, "a short option name can't be a number or a dash" if sopt =~ ::Optimist::Parser::INVALID_SHORT_ARG_REGEX
-    end
-    return sopt
   end
 
 end

--- a/test/optimist/alt_names_test.rb
+++ b/test/optimist/alt_names_test.rb
@@ -18,13 +18,25 @@ module Optimist
     end
 
     def test_altshort
-       @p.opt :catarg, "desc", :short => ["c", "-C"]
+      @p.opt :catarg, "desc", :short => ["c", "-C"]
        opts = @p.parse %w(-c)
        assert_equal true, opts[:catarg]
        opts = @p.parse %w(-C)
        assert_equal true, opts[:catarg]
        assert_raises(CommandlineError) { @p.parse %w(-c -C) }
        assert_raises(CommandlineError) { @p.parse %w(-cC) }
+    end
+
+    def test_altshort_invalid_none
+      assert_raises(ArgumentError) {
+        @p.opt :something, "some opt", :short => [:s, :none]
+      }
+      assert_raises(ArgumentError) {
+        @p.opt :something, "some opt", :short => [:none, :s]
+      }
+      assert_raises(ArgumentError) {
+        @p.opt :zumthing, "some opt", :short => [:none, :none]
+      }
     end
 
     def test_altshort_with_multi

--- a/test/optimist/alt_names_test.rb
+++ b/test/optimist/alt_names_test.rb
@@ -1,0 +1,147 @@
+require 'test_helper'
+
+module Optimist
+
+  class AlternateNamesTest < ::Minitest::Test
+
+    def setup
+      @p = Parser.new
+    end
+
+    def get_help_string
+      err = assert_raises(Optimist::HelpNeeded) do
+        @p.parse(%w(--help))
+      end
+      sio = StringIO.new "w"
+      @p.educate sio
+      sio.string
+    end
+
+    def test_altshort
+       @p.opt :catarg, "desc", :short => ["c", "-C"]
+       opts = @p.parse %w(-c)
+       assert_equal true, opts[:catarg]
+       opts = @p.parse %w(-C)
+       assert_equal true, opts[:catarg]
+       assert_raises(CommandlineError) { @p.parse %w(-c -C) }
+       assert_raises(CommandlineError) { @p.parse %w(-cC) }
+    end
+
+    def test_altshort_with_multi
+      @p.opt :flag, "desc", :short => ["-c", "C", :x], :multi => true
+      @p.opt :num, "desc", :short => ["-n", "N"], :multi => true, type: Integer
+      @p.parse %w(-c)
+      @p.parse %w(-C -c -x)
+      @p.parse %w(-c -C)
+      @p.parse %w(-c -C -c -C)
+      opts = @p.parse %w(-ccCx)
+      assert_equal true, opts[:flag]
+      @p.parse %w(-c)
+      @p.parse %w(-N 1 -n 3)
+      @p.parse %w(-n 2 -N 4)
+      opts = @p.parse %w(-n 4 -N 3 -n 2 -N 1)
+      assert_equal [4, 3, 2, 1], opts[:num]
+    end
+
+    def test_altlong
+      @p.opt "goodarg0", "desc", :alt => "zero"
+      @p.opt "goodarg1", "desc", :long => "newone", :alt => "one"
+      @p.opt "goodarg2", "desc", :alt => "--two"
+      @p.opt "goodarg3", "desc", :alt => ["three", "--four", :five]
+
+      [%w[--goodarg0], %w[--zero]].each do |a|
+        opts = @p.parse(a)
+        assert opts.goodarg0
+      end
+      
+      [%w[--newone], %w[-n], %w[--one]].each  do |a|
+        opts = @p.parse(a)
+        assert opts.goodarg1
+      end
+
+      [%w[--two]].each  do |a|
+        opts = @p.parse(a)
+        assert opts.goodarg2
+      end
+
+      [%w[--three], %w[--four], %w[--five]].each  do |a|
+        opts = @p.parse(a)
+        assert opts.goodarg3
+      end
+
+      [%w[--goodarg1], %w[--missing], %w[-a]].each do |a|
+        assert_raises(Optimist::CommandlineError) { @p.parse(a) }
+      end
+
+      ["", '--', '-bad', '---threedash'].each do |altitem|
+        assert_raises(ArgumentError) { @p.opt "badarg", "desc", :alt => altitem }
+      end
+    end
+    
+    def test_altshort_help
+      @p.opt :cat, 'cat', short: ['c','C','a','T']
+      outstring = get_help_string
+      # expect mutliple short-opts to be in the help
+      assert_match(/-c, -C, -a, -T, --cat/, outstring)
+    end
+
+    
+    def test_altlong_help
+      @p.opt :cat, 'a cat', alt: :feline
+      @p.opt :dog, 'a dog', alt: ['Pooch', :canine]
+      @p.opt :fruit, 'a fruit', long: :fig, alt: ['peach', :pear, "--apple"], short: :none
+      @p.opt :veg, "gemuse", long: :gemuse, alt: [:groente]
+      outstring = get_help_string
+
+      assert_match(/^\s*-c, --cat, --feline/, outstring)
+      assert_match(/^\s*-d, --dog, --Pooch, --canine/, outstring)
+
+      # expect long-opt to shadow the actual name
+      assert_match(/^\s*--fig, --peach, --pear, --apple/, outstring)
+      assert_match(/^\s*-g, --gemuse, --groente/, outstring)
+      
+    end
+
+    def test_alt_duplicates
+      # alt duplicates named option
+      assert_raises(ArgumentError) {
+        @p.opt :cat, 'desc', :alt => :cat
+      }
+      # alt duplicates :long 
+      assert_raises(ArgumentError) {
+        @p.opt :cat, 'desc', :long => :feline, :alt => [:feline]
+      }
+      # alt duplicates itself
+      assert_raises(ArgumentError) {
+        @p.opt :abc, 'desc', :alt => [:aaa, :aaa]
+      }
+    end
+    
+    def test_altlong_collisions
+      @p.opt :fat, 'desc'
+      @p.opt :raton, 'desc', :long => :rat
+      @p.opt :bat, 'desc', :alt => [:baton, :twirl]
+
+      # :alt collision with named option
+      assert_raises(ArgumentError) {
+        @p.opt :cat, 'desc', :alt => :fat
+      }
+
+      # :alt collision with :long option
+      assert_raises(ArgumentError) {
+        @p.opt :cat, 'desc', :alt => :rat
+      }
+
+      # :named option collision with existing :alt option
+      assert_raises(ArgumentError) {
+        @p.opt :baton, 'desc'
+      }
+
+      # :long option collision with existing :alt option
+      assert_raises(ArgumentError) {
+        @p.opt :whirl, 'desc', :long => 'twirl'
+      }
+      
+    end
+  end
+end

--- a/test/optimist/parser_test.rb
+++ b/test/optimist/parser_test.rb
@@ -528,8 +528,8 @@ with a multi-line description
     @p.educate(out)
     assert_equal <<-EOM, out.string
 Options:
-      --arg=<i>    This is an arg
-                   with a multi-line description
+  --arg=<i>    This is an arg
+               with a multi-line description
     EOM
   end
 
@@ -592,7 +592,11 @@ Options:
     assert_raises(ArgumentError) { @p.opt :arg, "desc", :short => "-1" }
     @p.opt :a1b, "desc"
     @p.opt :a2b, "desc"
-    assert @p.specs[:a2b].short.to_i == 0
+    @p.parse []
+    # testing private interface to ensure default
+    # short options did not become numeric
+    assert_equal @p.specs[:a1b].short.chars.first, 'a'
+    assert_equal @p.specs[:a2b].short.chars.first, 'b'
   end
 
   def test_short_options_can_be_weird
@@ -769,7 +773,7 @@ Options:
 
   def test_auto_generated_long_names_convert_underscores_to_hyphens
     @p.opt :hello_there
-    assert_equal "hello-there", @p.specs[:hello_there].long
+    assert_equal "hello-there", @p.specs[:hello_there].long.long
   end
 
   def test_arguments_passed_through_block


### PR DESCRIPTION
It can be useful to have more than one option name for the same option.  E.g. you may have a `--concat` option, but intuitively to some users they would rather `--append`.  Or sometimes you want to change names of the option but keep backward compatibility.
This enables short options and long options to have more than one name.

For short options, the `chars:` can now take a list of strings/symbols (previously was just a symbol or char)
For long options, the `alt:` takes additional alternate long options.  The value provided in `long:` is still respected, any name(s) given in `alt:` are used in addition to the default long-argument or what was provided in `long:`

There was some refactoring of how short and long options work, which pushed them down into a `ShortNames` and `LongNames` class.  This caused an update a couple of existing tests.  I think this is fine unless someone out there was accessing internals of the `Option` class, probing the `short` and `long` instance variables and expecting them to be strings.


@miq-bot add-label enhancement
@miq-bot add-reviewer @Fryguy 
+  @akhoury6 