### PR TITLE
Allow failures for ruby-head

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,3 +33,4 @@ jobs:
         bundler-cache: true
     - name: Run tests
       run: bundle exec rake
+      continue-on-error: ${{ matrix.ruby-version == 'ruby-head' }}


### PR DESCRIPTION
Temporarily allow failures for ruby-head until we can understand why it fails.