### PR TITLE
fixes frozen string issue on old rb2.7, removed useless code

### DIFF
--- a/lib/optimist.rb
+++ b/lib/optimist.rb
@@ -248,7 +248,6 @@ class Parser
 
   def handle_unknown_argument(arg, candidates, suggestions)
     errstring = "unknown argument '#{arg}'"
-    errstring += " for command '#{subcommand_name}'" if self.respond_to?(:subcommand_name)
     if (suggestions &&
       Module::const_defined?("DidYouMean") &&
       Module::const_defined?("DidYouMean::JaroWinkler") &&
@@ -275,7 +274,7 @@ class Parser
                     end
       unless corrections.empty?
         dashdash_corrections = corrections.map{|s| "--#{s}" }
-        errstring << ".  Did you mean: [#{dashdash_corrections.join(', ')}] ?"
+        errstring += ".  Did you mean: [#{dashdash_corrections.join(', ')}] ?"
       end
     end
     raise CommandlineError, errstring


### PR DESCRIPTION
Merge of did-you-mean branch and frozen-string literal branch caused this issue, as the DYM branch did not fully abide by frozen-string literal rules.

Funny enough, behavior of the frozen-string-literal comment is different on rb2.7 and 3.x
Fixes fails mentioned #152 

@miq-bot add-label bug
@miq-bot add-reviewer @Fryguy 

