### PR TITLE
Add exact_match to settings, defaulting to inexact matching

### DIFF
--- a/lib/optimist.rb
+++ b/lib/optimist.rb
@@ -856,7 +856,7 @@ class BooleanOption < Option
   end
   def flag? ; true ; end
   def parse(_paramlist, neg_given)
-    return(self.name.to_s.start_with("^no_") ? neg_given : !neg_given)
+    return(self.name.to_s =~ /^no_/ ? neg_given : !neg_given)
   end
 end
 

--- a/lib/optimist.rb
+++ b/lib/optimist.rb
@@ -84,7 +84,7 @@ class Parser
   ##  ignore options that it does not recognize.
   attr_accessor :ignore_invalid_options
 
-  DEFAULT_SETTINGS = { suggestions: true, exact_match: false }
+  DEFAULT_SETTINGS = { suggestions: true, exact_match: true }
 
   ## Initializes the parser, and instance-evaluates any block given.
   def initialize(*a, &b)

--- a/lib/optimist.rb
+++ b/lib/optimist.rb
@@ -1025,7 +1025,7 @@ end
 ##   end
 ##
 ##  +settings+ include:
-##  * :exact_match  : (default=false) Allow minimum unambigous number of characters to match a long option
+##  * :exact_match  : (default=true) Allow minimum unambigous number of characters to match a long option
 ##  * :suggestions  : (default=true) Enables suggestions when unknown arguments are given and DidYouMean is installed.  DidYouMean comes standard with Ruby 2.3+
 ##  Because Optimist::options uses a default argument for +args+, you must pass that argument when using the settings feature.
 ##

--- a/lib/optimist.rb
+++ b/lib/optimist.rb
@@ -85,7 +85,7 @@ class Parser
   attr_accessor :ignore_invalid_options
 
   DEFAULT_SETTINGS = { suggestions: true, exact_match: false }
-  
+
   ## Initializes the parser, and instance-evaluates any block given.
   def initialize(*a, &b)
     @version = nil
@@ -264,9 +264,9 @@ class Parser
   def handle_unknown_argument(arg, candidates, suggestions)
     errstring = "unknown argument '#{arg}'"
     if (suggestions &&
-        Module::const_defined?("DidYouMean") &&
-        Module::const_defined?("DidYouMean::JaroWinkler") &&
-        Module::const_defined?("DidYouMean::Levenshtein"))
+      Module::const_defined?("DidYouMean") &&
+      Module::const_defined?("DidYouMean::JaroWinkler") &&
+      Module::const_defined?("DidYouMean::Levenshtein"))
       input = arg.sub(/^[-]*/,'')
 
       # Code borrowed from did_you_mean gem
@@ -331,13 +331,13 @@ class Parser
         else                       raise CommandlineError, "invalid argument syntax: '#{arg}'"
       end
 
-      sym = nil if arg =~ /--no-/ # explicitly invalidate --no-no- arguments
-
+      if arg =~ /--no-/ # explicitly invalidate --no-no- arguments
+        sym = nil
       ## Support inexact matching of long-arguments like perl's Getopt::Long
-      if !sym && !@settings[:exact_match] && arg.match(/^--(\S*)$/)
+      elsif !sym && !@settings[:exact_match] && arg.match(/^--(\S*)$/)
         sym = perform_inexact_match(arg, $1)
       end
-      
+
       next nil if ignore_invalid_options && !sym
       handle_unknown_argument(arg, @long.keys, @settings[:suggestions]) unless sym
 

--- a/lib/optimist.rb
+++ b/lib/optimist.rb
@@ -334,7 +334,7 @@ class Parser
       if arg =~ /--no-/ # explicitly invalidate --no-no- arguments
         sym = nil
       ## Support inexact matching of long-arguments like perl's Getopt::Long
-      elsif !sym && !@settings[:exact_match] && arg.match(/^--(\S*)$/)
+      elsif !sym && !@settings[:exact_match] && arg.match(/^--(\S+)$/)
         sym = perform_inexact_match(arg, $1)
       end
 

--- a/test/optimist/parser_test.rb
+++ b/test/optimist/parser_test.rb
@@ -1178,7 +1178,7 @@ Options:
   end
 
   def test_inexact_match
-    newp = Parser.new()
+    newp = Parser.new(exact_match: false)
     newp.opt :liberation, "liberate something", :type => :int
     newp.opt :evaluate, "evaluate something", :type => :string
     opts = newp.parse %w(--lib 5 --ev bar)
@@ -1188,7 +1188,7 @@ Options:
   end
 
   def test_exact_match
-    newp = Parser.new(exact_match: true)
+    newp = Parser.new()
     newp.opt :liberation, "liberate something", :type => :int
     newp.opt :evaluate, "evaluate something", :type => :string
     assert_raises(CommandlineError, /unknown argument '--lib'/) do
@@ -1200,7 +1200,7 @@ Options:
   end
 
   def test_inexact_collision
-    newp = Parser.new()
+    newp = Parser.new(exact_match: false)
     newp.opt :bookname, "name of a book", :type => :string
     newp.opt :bookcost, "cost of the book", :type => :string
     opts = newp.parse %w(--bookn hairy_potsworth --bookc 10)
@@ -1216,13 +1216,12 @@ Options:
   end
 
   def test_inexact_collision_with_exact
-    newp = Parser.new()
+    newp = Parser.new(exact_match: false)
     newp.opt :book, "name of a book", :type => :string, :default => "ABC"
     newp.opt :bookcost, "cost of the book", :type => :int, :default => 5
     opts = newp.parse %w(--book warthog --bookc 3)
     assert_equal 'warthog', opts[:book]
     assert_equal 3, opts[:bookcost]
-
   end
 
   def test_accepts_arguments_with_spaces

--- a/test/optimist/parser_test.rb
+++ b/test/optimist/parser_test.rb
@@ -46,56 +46,11 @@ class ParserTest < ::Minitest::Test
 
   def test_unknown_arguments
     err = assert_raises(CommandlineError) { @p.parse(%w(--arg)) }
-    assert_match(/unknown argument '--arg'$/, err.message)
+    assert_match(/unknown argument '--arg'/, err.message)
     @p.opt "arg"
     @p.parse(%w(--arg))
     err = assert_raises(CommandlineError) { @p.parse(%w(--arg2)) }
-    assert_match(/unknown argument '--arg2'$/, err.message)
-  end
-  
-  def test_unknown_arguments_with_suggestions
-    sugp = Parser.new(:suggestions => true)
-    err = assert_raises(CommandlineError) { sugp.parse(%w(--bone)) }
-    assert_match(/unknown argument '--bone'$/, err.message)
-
-    if (Module::const_defined?("DidYouMean") &&
-        Module::const_defined?("DidYouMean::JaroWinkler") &&
-        Module::const_defined?("DidYouMean::Levenshtein"))
-      sugp.opt "cone"
-      sugp.parse(%w(--cone))
-
-      # single letter mismatch
-      err = assert_raises(CommandlineError) { sugp.parse(%w(--bone)) }
-      assert_match(/unknown argument '--bone'.  Did you mean: \[--cone\] \?$/, err.message)
-
-      # transposition
-      err = assert_raises(CommandlineError) { sugp.parse(%w(--ocne)) }
-      assert_match(/unknown argument '--ocne'.  Did you mean: \[--cone\] \?$/, err.message)
-
-      # extra letter at end
-      err = assert_raises(CommandlineError) { sugp.parse(%w(--cones)) }
-      assert_match(/unknown argument '--cones'.  Did you mean: \[--cone\] \?$/, err.message)
-
-      # too big of a mismatch to suggest (extra letters in front)
-      err = assert_raises(CommandlineError) { sugp.parse(%w(--snowcone)) }
-      assert_match(/unknown argument '--snowcone'$/, err.message)
-
-      # too big of a mismatch to suggest (nothing close)
-      err = assert_raises(CommandlineError) { sugp.parse(%w(--clown-nose)) }
-      assert_match(/unknown argument '--clown-nose'$/, err.message)
-
-      sugp.opt "zippy"
-      sugp.opt "zapzy"
-      # single letter mismatch, matches two
-      err = assert_raises(CommandlineError) { sugp.parse(%w(--zipzy)) }
-      assert_match(/unknown argument '--zipzy'.  Did you mean: \[--zippy, --zapzy\] \?$/, err.message)
-
-      sugp.opt "big_bug"
-      # suggest common case of dash versus underscore in argnames
-      err = assert_raises(CommandlineError) { sugp.parse(%w(--big_bug)) }
-      assert_match(/unknown argument '--big_bug'.  Did you mean: \[--big-bug\] \?$/, err.message)
-    end
-    
+    assert_match(/unknown argument '--arg2'/, err.message)
   end
 
   def test_unknown_arguments_with_suggestions
@@ -825,13 +780,13 @@ Options:
     end
     assert_equal @goat, boat
   end
-  
+
   ## test-only access reader method so that we dont have to
   ## expose settings in the public API.
   class Optimist::Parser
     def get_settings_for_testing ; return @settings ;end
   end
-  
+
   def test_two_arguments_passed_through_block
     newp = Parser.new(:abcd => 123, :efgh => "other" ) do |i|
     end
@@ -1229,7 +1184,7 @@ Options:
     opts = newp.parse %w(--lib 5 --ev bar)
     assert_equal 5, opts[:liberation]
     assert_equal 'bar', opts[:evaluate]
-    assert_equal nil, opts[:eval]
+    assert_nil opts[:eval]
   end
 
   def test_exact_match
@@ -1440,9 +1395,10 @@ Options:
       settings_copy = @settings
     end
     assert_equal [], passargs_copy
-    assert_equal({:fizz=>:buzz, :bear=>:cat}, settings_copy)
+    assert_equal settings_copy[:fizz], :buzz
+    assert_equal settings_copy[:bear], :cat
   end
-  
+
   def test_options_takes_some_other_data
     passargs_copy = []
     settings_copy = []
@@ -1453,7 +1409,7 @@ Options:
       settings_copy = @settings
     end
     assert_equal [1,2,3], passargs_copy
-    assert_equal({}, settings_copy)
+    assert_equal(Optimist::Parser::DEFAULT_SETTINGS, settings_copy)
   end
 end
 

--- a/test/support/assert_helpers.rb
+++ b/test/support/assert_helpers.rb
@@ -42,5 +42,11 @@ module Minitest::Assertions
     end
     flunk "#{msg}#{mu_pp(exp)} SystemExit expected but nothing was raised."
   end
+
+  # wrapper around common assertion checking pattern
+  def assert_raises_errmatch(err_klass, err_regexp, &b)
+    err = assert_raises(err_klass, &b)
+    assert_match(err_regexp, err.message)
+  end
 end
 


### PR DESCRIPTION
Add support for inexact long-option matches, inspired by Perl's Getopt::Long.

Allows the user to provide a leading substring of characters for a long-option so long as it is not ambiguous which option it references
E.g. if you have options `cake` and `carrot`, 
+ :heavy_check_mark: `--car`, `--carr`, `--carro`, `--carrot` can enable `carrot`
+ :heavy_check_mark: `--cak`, `--cake` can enable `cake`
+ :x: `--ca` is invalid because it is ambiguous.

The behavior is not enabled for `--no` options due to concerns over confusion.
The exact_match behavior is defaulted to true, but can be turned off by passing in settings. `exact_match: false`

Additional tests were added to clarify behavior around the settings hash.

@miq-bot add-label enhancement
@miq-bot add-reviewer @Fryguy 

