### PR TITLE
added settings to only create short options explicitly

### DIFF
--- a/lib/optimist.rb
+++ b/lib/optimist.rb
@@ -84,7 +84,11 @@ class Parser
   ##  ignore options that it does not recognize.
   attr_accessor :ignore_invalid_options
 
-  DEFAULT_SETTINGS = { suggestions: true, exact_match: true }
+  DEFAULT_SETTINGS = {
+    exact_match: true,
+    explicit_short_opts: false,
+    suggestions: true
+  }
 
   ## Initializes the parser, and instance-evaluates any block given.
   def initialize(*a, &b)
@@ -313,7 +317,7 @@ class Parser
       vals[sym] = [] if opts.multi && !opts.default # multi arguments default to [], not nil
     end
 
-    resolve_default_short_options!
+    resolve_default_short_options! unless @settings[:explicit_short_opts]
 
     ## resolve symbols
     given_args = {}
@@ -1027,6 +1031,7 @@ end
 ##  +settings+ include:
 ##  * :exact_match  : (default=true) Allow minimum unambigous number of characters to match a long option
 ##  * :suggestions  : (default=true) Enables suggestions when unknown arguments are given and DidYouMean is installed.  DidYouMean comes standard with Ruby 2.3+
+##  * :explicit_short_opts : (default=false) Short options will only be created where explicitly defined.  If you do not like short-options, this will prevent having to define :short=> :none for all of your options.
 ##  Because Optimist::options uses a default argument for +args+, you must pass that argument when using the settings feature.
 ##
 ## See more examples at https://www.manageiq.org/optimist

--- a/lib/optimist.rb
+++ b/lib/optimist.rb
@@ -86,7 +86,7 @@ class Parser
 
   DEFAULT_SETTINGS = {
     exact_match: true,
-    explicit_short_opts: false,
+    implicit_short_opts: true,
     suggestions: true
   }
 
@@ -317,7 +317,7 @@ class Parser
       vals[sym] = [] if opts.multi && !opts.default # multi arguments default to [], not nil
     end
 
-    resolve_default_short_options! unless @settings[:explicit_short_opts]
+    resolve_default_short_options! if @settings[:implicit_short_opts]
 
     ## resolve symbols
     given_args = {}
@@ -1031,7 +1031,7 @@ end
 ##  +settings+ include:
 ##  * :exact_match  : (default=true) Allow minimum unambigous number of characters to match a long option
 ##  * :suggestions  : (default=true) Enables suggestions when unknown arguments are given and DidYouMean is installed.  DidYouMean comes standard with Ruby 2.3+
-##  * :explicit_short_opts : (default=false) Short options will only be created where explicitly defined.  If you do not like short-options, this will prevent having to define :short=> :none for all of your options.
+##  * :implicit_short_opts : (default=true) Short options will only be created where explicitly defined.  If you do not like short-options, this will prevent having to define :short=> :none for all of your options.
 ##  Because Optimist::options uses a default argument for +args+, you must pass that argument when using the settings feature.
 ##
 ## See more examples at https://www.manageiq.org/optimist

--- a/test/optimist/parser_test.rb
+++ b/test/optimist/parser_test.rb
@@ -1178,7 +1178,7 @@ Options:
   end
 
   def test_short_opts_not_implicitly_created
-    newp = Parser.new(explicit_short_opts: true)
+    newp = Parser.new(implicit_short_opts: false)
     newp.opt :user1, "user1"
     newp.opt :bag, "bag", :short => 'b'
     assert_raises(CommandlineError) do
@@ -1191,9 +1191,9 @@ Options:
   end
 
   def test_short_opts_not_implicit_help_ver
-    # When explicit_short_opts is enabled this extends 
-    # to the built-in help/version also.
-    newp = Parser.new(explicit_short_opts: true)
+    # When implicit_short_opts is false this implies the short options
+    # for the built-in help/version are also not created.
+    newp = Parser.new(implicit_short_opts: false)
     newp.opt :abc, "abc"
     newp.version "3.4.5"
     assert_raises(CommandlineError) do

--- a/test/optimist/parser_test.rb
+++ b/test/optimist/parser_test.rb
@@ -1177,6 +1177,39 @@ Options:
     assert opts[:ccd]
   end
 
+  def test_short_opts_not_implicitly_created
+    newp = Parser.new(explicit_short_opts: true)
+    newp.opt :user1, "user1"
+    newp.opt :bag, "bag", :short => 'b'
+    assert_raises(CommandlineError) do
+      newp.parse %w(-u)
+    end
+    opts = newp.parse %w(--user1)
+    assert opts[:user1]
+    opts = newp.parse %w(-b)
+    assert opts[:bag]
+  end
+
+  def test_short_opts_not_implicit_help_ver
+    # When explicit_short_opts is enabled this extends 
+    # to the built-in help/version also.
+    newp = Parser.new(explicit_short_opts: true)
+    newp.opt :abc, "abc"
+    newp.version "3.4.5"
+    assert_raises(CommandlineError) do
+      newp.parse %w(-h)
+    end
+    assert_raises(CommandlineError) do
+      newp.parse %w(-v)
+    end
+    assert_raises(HelpNeeded) do
+      newp.parse %w(--help)
+    end
+    assert_raises(VersionNeeded) do
+      newp.parse %w(--version)
+    end
+  end
+
   def test_inexact_match
     newp = Parser.new(exact_match: false)
     newp.opt :liberation, "liberate something", :type => :int


### PR DESCRIPTION
In Optimist short options are automatically created for any given long option. (e.g: `-f` for `--file`)
Once enough options exist you are likely to have short-option name collisions, whereby you may compete for the short-option, and optimist must choose a backup short-letter e.g. 

```ruby
opt :file, "a filename", type: String
opt :format, "file format", type: String
```

Optimist wont allow collisions and thus it will go through letters to try to find a different unused letter.  In this case `-f` for `--file` and `-o` for `--format` (because the `f` was already used).  Unfortunately this makes the order of `opt` important.  If you do this:
```ruby
opt :format, "file format", type: String
opt :file, "a filename", type: String
```
then in this case you get `-f` for `--format` and `-i` for `--file`.

Often second choice short-arguments are not really what you want - it's not memorable.  Additionally re-ordering or re-grouping options changes the short letter which is undesirable for users.  IME, people tend to use the shortest means of enabling the option available so they get upset when you change the short-opt even though it's usually not as stable.

This can be fixed by using the `short:` argument for `opt`.  To disable short options for an `opt` you can use `short: :none`.  I often find that for less commonly used arguments I prefer to make the user call out the long form.  This means setting `short: :none` on a lot of options.  I prefer to set `short:` on **every** option to some value, so that I can ensure stability.

This PR allows you to disable the implicit short option generation for `opt`.  You can use the setting `explicit_short_opts: true` and this will prevent the automatic creation of all short opts.  Once this setting is applied, short opts can be enabled by explicitly adding `short: '<letter>'` to the `opt`.

Note that this implies that `-h` and `-v` for help/version are not automatically created when `--help` and `--version` are.  I'm a little conflicted about this, as `-h` is very common for a help message but it feels inconsistent to not do so.  the net result is explicit definition of `opt :help` in order to get both `--help/-h`.  Feedback appreciated.

If you don't add the `explicit_short_opts: true`, the present behavior of Optimist is unchanged.

@miq-bot enhancement
@miq-bot add-reviewer @Fryguy 
