### PR TITLE
enhancements to permitted option

### DIFF
--- a/lib/optimist.rb
+++ b/lib/optimist.rb
@@ -887,7 +887,7 @@ class Option
     case permitted
     when nil then true
     when Regexp then val.match? permitted
-    when Range then permitted.to_a.map(&:to_s).include? val
+    when Range then permitted.include? as_type(val)
     when Array then permitted.map(&:to_s).include? val
     else false
     end
@@ -1009,11 +1009,12 @@ end
 class FloatOption < Option
   register_alias :float, :double
   def type_format ; "=<f>" ; end
+  def as_type(param) ; param.to_f ; end
   def parse(paramlist, _neg_given)
     paramlist.map do |pg|
       pg.map do |param|
         raise CommandlineError, "option '#{self.name}' needs a floating-point number" unless param.is_a?(Numeric) || param =~ FLOAT_RE
-        param.to_f
+        as_type(param)
       end
     end
   end
@@ -1023,11 +1024,12 @@ end
 class IntegerOption < Option
   register_alias :int, :integer, :fixnum
   def type_format ; "=<i>" ; end
+  def as_type(param) ; param.to_i ; end
   def parse(paramlist, _neg_given)
     paramlist.map do |pg|
       pg.map do |param|
         raise CommandlineError, "option '#{self.name}' needs an integer" unless param.is_a?(Numeric) || param =~ /^-?[\d_]+$/
-        param.to_i
+        as_type(param)
       end
     end
   end
@@ -1060,9 +1062,10 @@ end
 # Option class for handling Strings.
 class StringOption < Option
   register_alias :string
+  def as_type(val) ; val.to_s ; end
   def type_format ; "=<s>" ; end
   def parse(paramlist, _neg_given)
-    paramlist.map { |pg| pg.map(&:to_s) }
+    paramlist.map { |pg| pg.map { |param| as_type(param) } }
   end
 end
 

--- a/test/optimist/parser_permitted_test.rb
+++ b/test/optimist/parser_permitted_test.rb
@@ -54,7 +54,18 @@ class ParserPermittedTest < ::Minitest::Test
     }
   end
 
-  def test_permitted_with_numeric_range
+  def test_permitted_with_string_range
+    @p.opt 'fiz', 'desc', :type => String, :permitted => 'A'..'z'
+    opts = @p.parse(%w(--fiz B))
+    assert_equal opts['fiz'], "B"
+    opts = @p.parse(%w(--fiz z))
+    assert_equal opts['fiz'], "z"
+    assert_raises_errmatch(CommandlineError, /option '--fiz' only accepts value in range of: A\.\.z/) {
+      @p.parse(%w(--fiz @))
+    }
+  end
+
+  def test_permitted_with_integer_range
     @p.opt 'fiz', 'desc', :type => Integer, :permitted => 1..3
     opts = @p.parse(%w(--fiz 1))
     assert_equal opts['fiz'], 1
@@ -62,6 +73,23 @@ class ParserPermittedTest < ::Minitest::Test
     assert_equal opts['fiz'], 3
     assert_raises_errmatch(CommandlineError, /option '--fiz' only accepts value in range of: 1\.\.3/) {
       @p.parse(%w(--fiz 4))
+    }
+  end
+
+  def test_permitted_with_float_range
+    @p.opt 'fiz', 'desc', :type => Float, :permitted => 1.2 .. 3.5
+    opts = @p.parse(%w(--fiz 1.2))
+    assert_in_epsilon opts['fiz'], 1.2
+    opts = @p.parse(%w(--fiz 2.7))
+    assert_in_epsilon opts['fiz'], 2.7
+    opts = @p.parse(%w(--fiz 3.5))
+    assert_in_epsilon opts['fiz'], 3.5
+    err_regexp = /option '--fiz' only accepts value in range of: 1\.2\.\.3\.5/
+    assert_raises_errmatch(CommandlineError, err_regexp) {
+      @p.parse(%w(--fiz 3.51))
+    }
+    assert_raises_errmatch(CommandlineError, err_regexp) {
+      @p.parse(%w(--fiz 1.19))
     }
   end
 


### PR DESCRIPTION
Fixes permitted range comparison issue.  Previously the range would be turned into an array which could blow up memory.
Adds more tests for permitted behavior.


@miq-bot add-label enhancement test
@miq-bot add-reviewer @Fryguy 
