### PR TITLE
Fix issues with frozen strings which fail jruby-head

### DIFF
--- a/test/optimist/alt_names_test.rb
+++ b/test/optimist/alt_names_test.rb
@@ -12,7 +12,7 @@ module Optimist
       assert_raises(Optimist::HelpNeeded) do
         @p.parse(%w(--help))
       end
-      sio = StringIO.new "w"
+      sio = StringIO.new
       @p.educate sio
       sio.string
     end

--- a/test/optimist/parser_educate_test.rb
+++ b/test/optimist/parser_educate_test.rb
@@ -40,7 +40,7 @@ module Optimist
 # pulled out of optimist_test for now
   def test_help_has_default_banner
     @p = Parser.new
-    sio = StringIO.new "w"
+    sio = StringIO.new
     @p.parse []
     @p.educate sio
     help = sio.string.split "\n"
@@ -49,7 +49,7 @@ module Optimist
 
     @p = Parser.new
     @p.version "my version"
-    sio = StringIO.new "w"
+    sio = StringIO.new
     @p.parse []
     @p.educate sio
     help = sio.string.split "\n"
@@ -58,7 +58,7 @@ module Optimist
 
     @p = Parser.new
     @p.banner "my own banner"
-    sio = StringIO.new "w"
+    sio = StringIO.new
     @p.parse []
     @p.educate sio
     help = sio.string.split "\n"
@@ -67,7 +67,7 @@ module Optimist
 
     @p = Parser.new
     @p.text "my own text banner"
-    sio = StringIO.new "w"
+    sio = StringIO.new
     @p.parse []
     @p.educate sio
     help = sio.string.split "\n"
@@ -78,7 +78,7 @@ module Optimist
   def test_help_has_optional_usage
     @p = Parser.new
     @p.usage "OPTIONS FILES"
-    sio = StringIO.new "w"
+    sio = StringIO.new
     @p.parse []
     @p.educate sio
     help = sio.string.split "\n"
@@ -89,7 +89,7 @@ module Optimist
   def test_help_has_optional_synopsis
     @p = Parser.new
     @p.synopsis "About this program"
-    sio = StringIO.new "w"
+    sio = StringIO.new
     @p.parse []
     @p.educate sio
     help = sio.string.split "\n"
@@ -101,7 +101,7 @@ module Optimist
     @p = Parser.new
     @p.usage "OPTIONS FILES"
     @p.synopsis "About this program"
-    sio = StringIO.new "w"
+    sio = StringIO.new
     @p.parse []
     @p.educate sio
     help = sio.string.split "\n"
@@ -113,7 +113,7 @@ module Optimist
   def test_help_preserves_positions
     parser.opt :zzz, "zzz"
     parser.opt :aaa, "aaa"
-    sio = StringIO.new "w"
+    sio = StringIO.new
     parser.educate sio
 
     help = sio.string.split "\n"
@@ -132,7 +132,7 @@ module Optimist
     parser.opt :arg8, 'arg', :type => :ios
     parser.opt :arg9, 'arg', :type => :date
     parser.opt :arg10, 'arg', :type => :dates
-    sio = StringIO.new "w"
+    sio = StringIO.new
     parser.educate sio
 
     help = sio.string.split "\n"
@@ -151,7 +151,7 @@ module Optimist
   def test_help_handles_boolean_flags
     parser.opt :default_false, 'default-false', :default => false
     parser.opt :default_true, 'default-true', :default => true
-    sio = StringIO.new "w"
+    sio = StringIO.new
     parser.educate sio
 
     help = sio.string.split "\n"
@@ -163,7 +163,7 @@ module Optimist
   def test_help_has_grammatical_default_text
     parser.opt :arg1, 'description with period.', :default => 'hello'
     parser.opt :arg2, 'description without period', :default => 'world'
-    sio = StringIO.new 'w'
+    sio = StringIO.new
     parser.educate sio
 
     help = sio.string.split "\n"
@@ -174,7 +174,7 @@ module Optimist
   def test_help_has_grammatical_permitted_text
     parser.opt :arg1, 'description with period.', :type => :strings, :permitted => %w(foo bar)
     parser.opt :arg2, 'description without period', :type => :strings, :permitted => %w(foo bar)
-    sio = StringIO.new 'w'
+    sio = StringIO.new
     parser.educate sio
 
     help = sio.string.split "\n"
@@ -185,7 +185,7 @@ module Optimist
   def test_help_with_permitted_range
     parser.opt :rating, 'rating', permitted: 1..5
     parser.opt :hex, 'hexadecimal', permitted: /^[0-9a-f]/i
-    sio = StringIO.new 'w'
+    sio = StringIO.new
     parser.educate sio
     help = sio.string.split "\n"
     assert_match %r{rating \(permitted: 1\.\.5\)}, help[1]

--- a/test/optimist/parser_test.rb
+++ b/test/optimist/parser_test.rb
@@ -368,7 +368,7 @@ class ParserTest < ::Minitest::Test
     @p.opt "arg", "desc", :short => :none
     @p.parse []
 
-    sio = StringIO.new "w"
+    sio = StringIO.new
     @p.educate sio
     assert sio.string =~ /--arg\s+desc/
 

--- a/test/support/assert_helpers.rb
+++ b/test/support/assert_helpers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Minitest::Assertions
   def assert_parses_correctly(parser, commandline, expected_opts,
                               expected_leftovers)
@@ -9,7 +11,7 @@ module Minitest::Assertions
   def assert_stderr(str = nil, msg = nil)
     msg = "#{msg}.\n" if msg
 
-    old_stderr, $stderr = $stderr, StringIO.new('')
+    old_stderr, $stderr = $stderr, StringIO.new
     yield
     assert_match str, $stderr.string, msg if str
   ensure
@@ -19,7 +21,7 @@ module Minitest::Assertions
   def assert_stdout(str = nil, msg = nil)
     msg = "#{msg}.\n" if msg
 
-    old_stdout, $stdout = $stdout, StringIO.new('')
+    old_stdout, $stdout = $stdout, StringIO.new
     yield
     assert_match str, $stdout.string, msg if str
   ensure


### PR DESCRIPTION
These tests are passing in a default value to StringIO, which is unnecessary (and in the case of the "w" is incorrect). That default value is a frozen string literal, which StringIO will later modify, leading to an error. Since they aren't needed we can remove them.

@kbrock Please review.
