### PR TITLE
Reduce gem size by excluding test files

### DIFF
--- a/optimist.gemspec
+++ b/optimist.gemspec
@@ -18,9 +18,7 @@ specify."
   spec.homepage      = "http://manageiq.github.io/optimist/"
   spec.license       = "MIT"
 
-  spec.files         = `git ls-files -z`.split("\x0")
-  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
-  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
+  spec.files         = `git ls-files lib`.split("\n") + ["CHANGELOG.md", "LICENSE.txt", "README.md"]
   spec.metadata    = {
     "changelog_uri"   => "https://github.com/ManageIQ/optimist/blob/master/CHANGELOG.md",
     "source_code_uri" => "https://github.com/ManageIQ/optimist/",


### PR DESCRIPTION
This pull request updates the *.gemspec file to optimize the gem package size and structure

```bash
$ gem build -o before.tar

$ git switch reduce-gem-size

$ gem build -o after.tar

$ du -sh before.tar after.tar
 28K	before.tar
 16K	after.tar
 ```
 
| Metric | Before | After | Saved                 |
|--------|--------|-------|-----------------------|
| Size   | 28K   | 16K   | −20K (⏷ −45.5%)    |


###  whitch files was deleted?

```diff
data
-├── .github
-│   └── workflows
-│       └── ci.yaml
-├── examples
-│   ├── a_basic_example.rb
-│   ├── alt_names.rb
-│   ├── banners1.rb
-│   ├── banners2.rb
-│   ├── banners3.rb
-│   ├── boolean.rb
-│   ├── constraints.rb
-│   ├── didyoumean.rb
-│   ├── medium_example.rb
-│   ├── partialmatch.rb
-│   ├── permitted.rb
-│   └── types_custom.rb
 ├── lib
 │   └── optimist.rb
-├── test
-│   ├── optimist
-│   │   ├── alt_names_test.rb
-│   │   ├── command_line_error_test.rb
-│   │   ├── help_needed_test.rb
-│   │   ├── parser_constraint_test.rb
-│   │   ├── parser_educate_test.rb
-│   │   ├── parser_opt_test.rb
-│   │   ├── parser_parse_test.rb
-│   │   ├── parser_permitted_test.rb
-│   │   ├── parser_test.rb
-│   │   └── version_needed_test.rb
-│   ├── support
-│   │   └── assert_helpers.rb
-│   ├── optimist_test.rb
-│   └── test_helper.rb
-├── .gitignore
-├── .rubocop_local.yml
-├── .rubocop.yml
-├── .whitesource
 ├── CHANGELOG.md
-├── FAQ.txt
-├── Gemfile
 ├── LICENSE.txt
-├── optimist.gemspec
-├── Rakefile
 ├── README.md
-└── renovate.json
```

ps: you can see on [rails repo](https://github.com/rails/rails/blob/main/actioncable/actioncable.gemspec#L20)