### PR TITLE
CI: Add Ruby 4.0, JRuby 10.1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,6 +26,8 @@ jobs:
         - '3.2'
         - '3.3'
         - '3.4'
+        - '4.0'
+        - jruby-10.1
         - jruby-9.4
         - ruby-head
         - jruby-head


### PR DESCRIPTION
These are GA, there are many EOL Ruby versions in the matrix. I chose not to drop them right now. At the time of writing, JRuby 9.4 has entered EOL.

Ruby 3.3 is still in support. https://endoflife.date/ruby
  